### PR TITLE
Store playerId in Authentication Details

### DIFF
--- a/src/main/java/com/sayai/record/auth/jwt/CustomUserDetails.java
+++ b/src/main/java/com/sayai/record/auth/jwt/CustomUserDetails.java
@@ -1,0 +1,17 @@
+package com.sayai.record.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class CustomUserDetails extends User {
+    private final Long playerId;
+
+    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities, Long playerId) {
+        super(username, password, authorities);
+        this.playerId = playerId;
+    }
+}

--- a/src/main/java/com/sayai/record/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sayai/record/auth/jwt/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package com.sayai.record.auth.jwt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,17 +26,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtTokenProvider.validateToken(token)) {
             String userId = jwtTokenProvider.getUserId(token);
             String role = jwtTokenProvider.getRole(token);
+            Long playerId = jwtTokenProvider.getPlayerId(token);
 
-            UserDetails userDetails = User.builder()
-                    .username(userId)
-                    .password("") // Password not needed here
-                    .authorities(Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role)))
-                    .build();
+            UserDetails userDetails = new CustomUserDetails(
+                    userId,
+                    "",
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role)),
+                    playerId
+            );
 
-            // We can store playerId in the details or as a custom Principal.
-            // For simplicity, sticking to standard UserDetails but ensure context is set.
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-            // Store playerId in details if needed, or just rely on username if that's unique
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/test/java/com/sayai/record/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sayai/record/auth/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,83 @@
+package com.sayai.record.auth.jwt;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void doFilterInternal_validToken_setsAuthentication() throws Exception {
+        String token = "valid-token";
+        String userId = "testUser";
+        String role = "USER";
+        Long playerId = 123L;
+
+        when(jwtTokenProvider.resolveToken(request)).thenReturn(token);
+        when(jwtTokenProvider.validateToken(token)).thenReturn(true);
+        when(jwtTokenProvider.getUserId(token)).thenReturn(userId);
+        when(jwtTokenProvider.getRole(token)).thenReturn(role);
+        when(jwtTokenProvider.getPlayerId(token)).thenReturn(playerId);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        assertTrue(principal instanceof CustomUserDetails);
+        CustomUserDetails userDetails = (CustomUserDetails) principal;
+        assertEquals(userId, userDetails.getUsername());
+        assertEquals(playerId, userDetails.getPlayerId());
+    }
+
+    @Test
+    void doFilterInternal_invalidToken_doesNotSetAuthentication() throws Exception {
+        String token = "invalid-token";
+
+        when(jwtTokenProvider.resolveToken(request)).thenReturn(token);
+        when(jwtTokenProvider.validateToken(token)).thenReturn(false);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}


### PR DESCRIPTION
Implemented CustomUserDetails to store playerId in the Spring Security Authentication object. Updated JwtAuthenticationFilter to populate this custom principal from the JWT token. Added unit tests for JwtAuthenticationFilter.

---
*PR created automatically by Jules for task [12558809127848133747](https://jules.google.com/task/12558809127848133747) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication system to carry additional player identifier information through authentication tokens and the security context, enabling more granular user identification and tracking throughout the application.

* **Tests**
  * Added comprehensive unit tests for the authentication filter, covering both valid token authentication scenarios with proper identifier extraction and invalid token handling with appropriate security responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->