### PR TITLE
Verify real user context in Fantasy Draft Room

### DIFF
--- a/src/test/java/com/sayai/record/fantasy/controller/FantasyViewControllerTest.java
+++ b/src/test/java/com/sayai/record/fantasy/controller/FantasyViewControllerTest.java
@@ -1,0 +1,62 @@
+package com.sayai.record.fantasy.controller;
+
+import com.sayai.record.auth.entity.Member;
+import com.sayai.record.auth.jwt.JwtTokenProvider;
+import com.sayai.record.auth.repository.MemberRepository;
+import com.sayai.record.fantasy.service.FantasyGameService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(FantasyViewController.class)
+class FantasyViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FantasyGameService fantasyGameService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @WithMockUser(username = "user1")
+    void testDraftRoomWithAuthenticatedUser() throws Exception {
+        // Given
+        Long playerId = 100L;
+        Long gameSeq = 1L;
+        Long draftingGameSeq = 1L;
+
+        Member member = Member.builder()
+                .playerId(playerId)
+                .userId("user1")
+                .name("Test User")
+                .password("password")
+                .role(Member.Role.USER)
+                .build();
+
+        given(memberRepository.findByUserId("user1")).willReturn(Optional.of(member));
+        given(fantasyGameService.findDraftingGameId(playerId)).willReturn(draftingGameSeq);
+
+        // When & Then
+        mockMvc.perform(get("/fantasy/draft/{gameSeq}", gameSeq))
+                .andExpect(status().isOk())
+                .andExpect(view().name("fantasy/draft"))
+                .andExpect(model().attribute("gameSeq", gameSeq))
+                .andExpect(model().attribute("currentUserId", playerId))
+                .andExpect(model().attribute("draftingGameSeq", draftingGameSeq));
+    }
+}


### PR DESCRIPTION
This PR verifies the implementation of real user context in the Fantasy Draft Room.

**Changes:**
- Added `FantasyViewControllerTest.java` to test that `FantasyViewController` injects the correct `currentUserId` into the model when a user is authenticated.

**Verification:**
- Run `./gradlew test --tests com.sayai.record.fantasy.controller.FantasyViewControllerTest` to confirm that the test passes.
- The test mocks an authenticated user and asserts that the `currentUserId` model attribute matches the user's `playerId`.

Note: The implementation code in `FantasyViewController.java` was already correct (using `@ModelAttribute` and `@AuthenticationPrincipal`), so no changes were needed there. The test serves as regression testing and verification of the fix.

---
*PR created automatically by Jules for task [1027660010051224217](https://jules.google.com/task/1027660010051224217) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the fantasy draft room endpoint to ensure proper HTTP responses, view rendering, and model data accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->