### PR TITLE
Implement Fantasy Draft Logic (Snake Order, Rules, Timer)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
 	implementation 'org.jsoup:jsoup:1.14.2'
 	implementation 'org.apache.poi:poi-ooxml:5.2.3'

--- a/src/main/java/com/sayai/record/RecordApplication.java
+++ b/src/main/java/com/sayai/record/RecordApplication.java
@@ -2,7 +2,9 @@ package com.sayai.record;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class RecordApplication {
 

--- a/src/main/java/com/sayai/record/admin/controller/AdminController.java
+++ b/src/main/java/com/sayai/record/admin/controller/AdminController.java
@@ -29,7 +29,8 @@ public class AdminController {
                 request.getScoringSettings(),
                 request.getMaxParticipants(),
                 request.getDraftDate(),
-                request.getGameDuration()
+                request.getGameDuration(),
+                request.getDraftTimeLimit()
         );
 
         return ResponseEntity.ok(game);
@@ -67,6 +68,7 @@ public class AdminController {
         private String scoringSettings;
         private Integer maxParticipants;
         private LocalDateTime draftDate;
+        private Integer draftTimeLimit;
         private String gameDuration;
     }
 }

--- a/src/main/java/com/sayai/record/config/ThymeleafConfig.java
+++ b/src/main/java/com/sayai/record/config/ThymeleafConfig.java
@@ -1,0 +1,14 @@
+package com.sayai.record.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect;
+
+@Configuration
+public class ThymeleafConfig {
+
+    @Bean
+    public SpringSecurityDialect springSecurityDialect() {
+        return new SpringSecurityDialect();
+    }
+}

--- a/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
@@ -44,6 +44,12 @@ public class FantasyGameController {
         return ResponseEntity.ok(fantasyGameService.getGameDetails(gameSeq));
     }
 
+    @PostMapping("/games/{gameSeq}/start")
+    public ResponseEntity<String> startGame(@PathVariable(name = "gameSeq") Long gameSeq) {
+        fantasyGameService.startGame(gameSeq);
+        return ResponseEntity.ok("Draft Started");
+    }
+
     private Long getPlayerIdFromUserDetails(UserDetails userDetails) {
         if (userDetails == null) {
             // For now, if no auth, maybe return default or throw 401.

--- a/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
@@ -45,7 +45,15 @@ public class FantasyGameController {
     }
 
     @PostMapping("/games/{gameSeq}/start")
-    public ResponseEntity<String> startGame(@PathVariable(name = "gameSeq") Long gameSeq) {
+    public ResponseEntity<String> startGame(@PathVariable(name = "gameSeq") Long gameSeq,
+                                            @AuthenticationPrincipal UserDetails userDetails) {
+        boolean isAdmin = userDetails.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            return ResponseEntity.status(403).body("Only Admin can start the draft");
+        }
+
         fantasyGameService.startGame(gameSeq);
         return ResponseEntity.ok("Draft Started");
     }

--- a/src/main/java/com/sayai/record/fantasy/dto/DraftEventDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/DraftEventDto.java
@@ -3,10 +3,13 @@ package com.sayai.record.fantasy.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
 @Builder
 public class DraftEventDto {
-    private String type; // "PICK" or "JOIN" or "STATUS"
+    private String type; // "PICK" or "JOIN" or "STATUS" or "START"
     private Long fantasyGameSeq;
     private Long playerId;
     private Long fantasyPlayerSeq;
@@ -14,4 +17,13 @@ public class DraftEventDto {
     private String playerTeam;
     private Integer pickNumber;
     private String message;
+
+    // Next Pick Info
+    private Long nextPickerId;
+    private LocalDateTime nextPickDeadline;
+    private Integer round;
+    private Integer pickInRound;
+
+    // For START event
+    private List<ParticipantRosterDto> draftOrder;
 }

--- a/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -23,5 +24,7 @@ public class FantasyGameDetailDto {
     private String gameDuration;
     private Integer participantCount;
     private Integer maxParticipants;
+    private Long nextPickerId;
+    private LocalDateTime nextPickDeadline;
     private List<ParticipantRosterDto> participants;
 }

--- a/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
@@ -26,5 +26,7 @@ public class FantasyGameDetailDto {
     private Integer maxParticipants;
     private Long nextPickerId;
     private LocalDateTime nextPickDeadline;
+    private Integer round;
+    private Integer pickInRound;
     private List<ParticipantRosterDto> participants;
 }

--- a/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
@@ -26,7 +26,7 @@ public class FantasyGameDetailDto {
     private Integer maxParticipants;
     private Long nextPickerId;
     private LocalDateTime nextPickDeadline;
-    private Integer round;
+    private Integer roundNum;
     private Integer pickInRound;
     private List<ParticipantRosterDto> participants;
 }

--- a/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDto.java
@@ -17,6 +17,7 @@ public class FantasyGameDto {
     private String scoringSettings;
     private Integer maxParticipants;
     private LocalDateTime draftDate;
+    private Integer draftTimeLimit;
     private String gameDuration;
     private LocalDateTime createdAt;
 
@@ -35,6 +36,7 @@ public class FantasyGameDto {
                 .scoringSettings(game.getScoringSettings())
                 .maxParticipants(game.getMaxParticipants())
                 .draftDate(game.getDraftDate())
+                .draftTimeLimit(game.getDraftTimeLimit())
                 .gameDuration(game.getGameDuration())
                 .createdAt(game.getCreatedAt())
                 .build();

--- a/src/main/java/com/sayai/record/fantasy/dto/ParticipantRosterDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/ParticipantRosterDto.java
@@ -16,5 +16,7 @@ import java.util.List;
 public class ParticipantRosterDto {
     private Long participantId;
     private String teamName;
+    private String preferredTeam;
+    private Integer draftOrder;
     private List<FantasyPlayerDto> roster;
 }

--- a/src/main/java/com/sayai/record/fantasy/entity/FantasyGame.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/FantasyGame.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -34,6 +35,10 @@ public class FantasyGame {
     private Integer maxParticipants;
     private LocalDateTime draftDate;
 
+    private Integer draftTimeLimit; // Minutes. 0 = No limit.
+
+    private LocalDateTime nextPickDeadline;
+
     private String gameDuration;
 
     private LocalDateTime createdAt;
@@ -53,6 +58,9 @@ public class FantasyGame {
         }
         if (this.scoringType == null) {
             this.scoringType = ScoringType.POINTS; // Default
+        }
+        if (this.draftTimeLimit == null) {
+            this.draftTimeLimit = 10;
         }
     }
 

--- a/src/main/java/com/sayai/record/fantasy/entity/FantasyParticipant.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/FantasyParticipant.java
@@ -5,6 +5,7 @@ import lombok.*;
 import jakarta.persistence.*;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -24,4 +25,6 @@ public class FantasyParticipant {
     private String teamName;
 
     private String preferredTeam;
+
+    private Integer draftOrder;
 }

--- a/src/main/java/com/sayai/record/fantasy/repository/FantasyGameRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/FantasyGameRepository.java
@@ -2,6 +2,14 @@ package com.sayai.record.fantasy.repository;
 
 import com.sayai.record.fantasy.entity.FantasyGame;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface FantasyGameRepository extends JpaRepository<FantasyGame, Long> {
+
+    @Query("SELECT g FROM FantasyGame g WHERE g.status = :status AND g.draftTimeLimit > 0 AND g.nextPickDeadline < :now")
+    List<FantasyGame> findExpiredDraftingGames(@Param("status") FantasyGame.GameStatus status, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sayai/record/fantasy/repository/FantasyPlayerRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/FantasyPlayerRepository.java
@@ -10,8 +10,8 @@ import java.util.List;
 public interface FantasyPlayerRepository extends JpaRepository<FantasyPlayer, Long> {
 
     @Query("SELECT p FROM FantasyPlayer p WHERE " +
-            "(:team IS NULL OR p.team LIKE CONCAT('%', :team, '%')) AND " +
-            "(:position IS NULL OR p.position LIKE CONCAT('%', :position, '%')) AND " +
+            "(:team IS NULL OR p.team = :team) AND " +
+            "(:position IS NULL OR p.position = :position) AND " +
             "(:search IS NULL OR p.name LIKE CONCAT('%', :search, '%'))")
     List<FantasyPlayer> findPlayers(@Param("team") String team,
                                     @Param("position") String position,

--- a/src/main/java/com/sayai/record/fantasy/repository/FantasyPlayerRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/FantasyPlayerRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface FantasyPlayerRepository extends JpaRepository<FantasyPlayer, Long> {
 
     @Query("SELECT p FROM FantasyPlayer p WHERE " +
-            "(:team IS NULL OR p.team = :team) AND " +
+            "(:team IS NULL OR p.team LIKE CONCAT('%', :team, '%')) AND " +
             "(:position IS NULL OR p.position LIKE CONCAT('%', :position, '%')) AND " +
             "(:search IS NULL OR p.name LIKE CONCAT('%', :search, '%'))")
     List<FantasyPlayer> findPlayers(@Param("team") String team,

--- a/src/main/java/com/sayai/record/fantasy/service/DraftScheduler.java
+++ b/src/main/java/com/sayai/record/fantasy/service/DraftScheduler.java
@@ -3,6 +3,7 @@ package com.sayai.record.fantasy.service;
 import com.sayai.record.fantasy.entity.FantasyGame;
 import com.sayai.record.fantasy.repository.FantasyGameRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DraftScheduler {
@@ -27,7 +29,7 @@ public class DraftScheduler {
                 // Double check status in case it changed
                 fantasyDraftService.autoPick(game.getSeq());
             } catch (Exception e) {
-                System.err.println("Error in autoPick for game " + game.getSeq() + ": " + e.getMessage());
+                log.error("Error in autoPick for game {}: {}", game.getSeq(), e.getMessage());
             }
         }
     }

--- a/src/main/java/com/sayai/record/fantasy/service/DraftScheduler.java
+++ b/src/main/java/com/sayai/record/fantasy/service/DraftScheduler.java
@@ -1,0 +1,34 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class DraftScheduler {
+
+    private final FantasyGameRepository fantasyGameRepository;
+    private final FantasyDraftService fantasyDraftService;
+
+    @Scheduled(fixedRate = 10000) // Check every 10 seconds
+    public void checkDraftTimeouts() {
+        // Find DRAFTING games with deadline < NOW and timeLimit > 0
+        List<FantasyGame> draftingGames = fantasyGameRepository.findExpiredDraftingGames(FantasyGame.GameStatus.DRAFTING, LocalDateTime.now());
+
+        for (FantasyGame game : draftingGames) {
+            try {
+                // Double check status in case it changed
+                fantasyDraftService.autoPick(game.getSeq());
+            } catch (Exception e) {
+                System.err.println("Error in autoPick for game " + game.getSeq() + ": " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/sayai/record/fantasy/service/DraftValidator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/DraftValidator.java
@@ -28,4 +28,12 @@ public class DraftValidator {
         }
         validator.validate(game, newPlayer, currentTeam, participant);
     }
+
+    public int getTotalPlayerCount(FantasyGame.RuleType ruleType) {
+        DraftRuleValidator validator = validatorMap.get(ruleType);
+        if (validator == null) {
+            throw new IllegalArgumentException("No validator found for rule type: " + ruleType);
+        }
+        return validator.getTotalPlayerCount();
+    }
 }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -16,6 +16,9 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -82,6 +85,12 @@ public class FantasyDraftService {
             throw new IllegalStateException("Game is not in DRAFTING status");
         }
 
+        // Check Turn
+        NextPickInfo nextPick = getNextPickInfo(game);
+        if (!nextPick.pickerId.equals(request.getPlayerId())) {
+            throw new IllegalStateException("It is not your turn. Current turn: " + nextPick.pickerId);
+        }
+
         // 2. Check availability
         boolean isPicked = draftPickRepository.existsByFantasyGameSeqAndFantasyPlayerSeq(
                 request.getFantasyGameSeq(),
@@ -126,6 +135,15 @@ public class FantasyDraftService {
 
         draftPickRepository.save(pick);
 
+        // Update Deadline for NEXT pick
+        if (game.getDraftTimeLimit() != null && game.getDraftTimeLimit() > 0) {
+            game.setNextPickDeadline(LocalDateTime.now().plusMinutes(game.getDraftTimeLimit()));
+            // No need to save game explicitly if transaction handles dirty check, but safest to save or rely on transactional
+        }
+
+        // Get NEXT Pick Info
+        NextPickInfo nextNext = getNextPickInfo(game);
+
         // Broadcast Event
         DraftEventDto event = DraftEventDto.builder()
                 .type("PICK")
@@ -136,9 +154,47 @@ public class FantasyDraftService {
                 .playerTeam(targetPlayer.getTeam())
                 .pickNumber(pickNumber)
                 .message("Player " + request.getPlayerId() + " picked " + targetPlayer.getName() + " (Pick #" + pickNumber + ")")
+                .nextPickerId(nextNext.pickerId)
+                .nextPickDeadline(game.getNextPickDeadline())
+                .round(nextNext.round)
+                .pickInRound(nextNext.pickInRound)
                 .build();
 
         messagingTemplate.convertAndSend("/topic/draft/" + request.getFantasyGameSeq(), event);
+    }
+
+    public static class NextPickInfo {
+        public Long pickerId;
+        public int round;
+        public int pickInRound;
+    }
+
+    public NextPickInfo getNextPickInfo(FantasyGame game) {
+        long totalPicks = draftPickRepository.countByFantasyGameSeq(game.getSeq());
+        List<FantasyParticipant> participants = fantasyParticipantRepository.findByFantasyGameSeq(game.getSeq());
+        participants.sort(Comparator.comparingInt(FantasyParticipant::getDraftOrder));
+        int n = participants.size();
+        if (n == 0) throw new IllegalStateException("No participants");
+
+        int round = (int) (totalPicks / n) + 1;
+        int index = (int) (totalPicks % n); // 0 to n-1
+
+        int draftOrderIndex; // 1-based draftOrder
+        if (round % 2 != 0) { // Odd
+            draftOrderIndex = index + 1;
+        } else { // Even (Snake)
+            draftOrderIndex = n - index;
+        }
+
+        // Find participant with this draftOrder
+        // Since list is sorted by draftOrder, index is draftOrderIndex - 1
+        FantasyParticipant nextPicker = participants.get(draftOrderIndex - 1);
+
+        NextPickInfo info = new NextPickInfo();
+        info.pickerId = nextPicker.getPlayerId();
+        info.round = round;
+        info.pickInRound = index + 1;
+        return info;
     }
 
     @Transactional(readOnly = true)
@@ -153,5 +209,74 @@ public class FantasyDraftService {
         return players.stream()
                 .map(FantasyPlayerDto::from)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void autoPick(Long gameSeq) {
+        FantasyGame game = fantasyGameRepository.findById(gameSeq)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Game Seq"));
+
+        if (game.getStatus() != FantasyGame.GameStatus.DRAFTING) {
+            return;
+        }
+
+        NextPickInfo nextPick = getNextPickInfo(game);
+        Long playerId = nextPick.pickerId;
+
+        // Fetch needed data
+        List<DraftPick> picks = draftPickRepository.findByFantasyGameSeq(gameSeq);
+        Set<Long> pickedPlayerSeqs = picks.stream()
+                .map(DraftPick::getFantasyPlayerSeq)
+                .collect(Collectors.toSet());
+
+        List<FantasyPlayer> allPlayers = fantasyPlayerRepository.findAll();
+        List<FantasyPlayer> available = allPlayers.stream()
+                .filter(p -> !pickedPlayerSeqs.contains(p.getSeq()))
+                .collect(Collectors.toList());
+
+        FantasyParticipant participant = fantasyParticipantRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId).orElseThrow();
+        List<FantasyPlayer> candidates = available;
+
+        // Rule 2 Logic for Auto Pick
+        if (game.getRuleType() == FantasyGame.RuleType.RULE_2 && nextPick.round == 1) {
+             String pref = participant.getPreferredTeam();
+             if (pref != null) {
+                 String prefLower = pref.trim().toLowerCase();
+                 candidates = available.stream().filter(p ->
+                     p.getTeam().toLowerCase().contains(prefLower) ||
+                     prefLower.contains(p.getTeam().toLowerCase())
+                 ).collect(Collectors.toList());
+             }
+        }
+
+        Collections.shuffle(candidates);
+
+        // Prepare current team for validation
+        List<DraftPick> userPicks = picks.stream().filter(p -> p.getPlayerId().equals(playerId)).collect(Collectors.toList());
+        Set<Long> userPickedSeqs = userPicks.stream().map(DraftPick::getFantasyPlayerSeq).collect(Collectors.toSet());
+        // Optimize: we have allPlayers, can find from there
+        List<FantasyPlayer> currentTeam = allPlayers.stream().filter(p -> userPickedSeqs.contains(p.getSeq())).collect(Collectors.toList());
+
+        FantasyPlayer selected = null;
+        for (FantasyPlayer p : candidates) {
+            try {
+                draftValidator.validate(game, p, currentTeam, participant);
+                selected = p;
+                break;
+            } catch (Exception e) {
+                // Invalid, try next
+            }
+        }
+
+        if (selected != null) {
+            DraftRequest req = new DraftRequest();
+            req.setFantasyGameSeq(gameSeq);
+            req.setFantasyPlayerSeq(selected.getSeq());
+            req.setPlayerId(playerId);
+            draftPlayer(req);
+        } else {
+            // Log or handle no valid pick found
+            System.err.println("AutoPick failed: No valid player found for game " + gameSeq + " user " + playerId);
+        }
     }
 }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -12,6 +12,7 @@ import com.sayai.record.fantasy.repository.FantasyGameRepository;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import com.sayai.record.fantasy.repository.FantasyPlayerRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FantasyDraftService {
@@ -220,6 +222,11 @@ public class FantasyDraftService {
             return;
         }
 
+        // Validate deadline again to avoid race conditions
+        if (game.getNextPickDeadline() != null && game.getNextPickDeadline().isAfter(LocalDateTime.now())) {
+            return;
+        }
+
         NextPickInfo nextPick = getNextPickInfo(game);
         Long playerId = nextPick.pickerId;
 
@@ -276,7 +283,7 @@ public class FantasyDraftService {
             draftPlayer(req);
         } else {
             // Log or handle no valid pick found
-            System.err.println("AutoPick failed: No valid player found for game " + gameSeq + " user " + playerId);
+            log.error("AutoPick failed: No valid player found for game {} user {}", gameSeq, playerId);
         }
     }
 }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -147,13 +147,14 @@ public class FantasyDraftService {
         // Get NEXT Pick Info
         NextPickInfo nextNext = getNextPickInfo(game);
 
-        // Check for Draft Completion (18 players per participant)
-        // Note: Rule 1 & 2 share this 18-player limit? Assuming yes for now.
+        // Check for Draft Completion
         long totalPicks = draftPickRepository.countByFantasyGameSeq(request.getFantasyGameSeq());
         List<FantasyParticipant> participants = fantasyParticipantRepository.findByFantasyGameSeq(request.getFantasyGameSeq());
 
+        int totalPlayersPerParticipant = draftValidator.getTotalPlayerCount(game.getRuleType());
+
         boolean isFinished = false;
-        if (!participants.isEmpty() && totalPicks >= participants.size() * 18L) {
+        if (!participants.isEmpty() && totalPicks >= participants.size() * (long)totalPlayersPerParticipant) {
             game.setStatus(FantasyGame.GameStatus.ONGOING);
             game.setNextPickDeadline(null);
             fantasyGameRepository.save(game); // Ensure status persist

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -267,7 +267,7 @@ public class FantasyGameService {
                 .maxParticipants(game.getMaxParticipants())
                 .nextPickerId(nextPickerId)
                 .nextPickDeadline(game.getNextPickDeadline())
-                .round(round)
+                .roundNum(round)
                 .pickInRound(pickInRound)
                 .participants(rosterDtos)
                 .build();

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -223,9 +223,14 @@ public class FantasyGameService {
 
         // Calculate Next Picker (if Drafting)
         Long nextPickerId = null;
+        Integer round = null;
+        Integer pickInRound = null;
         if (game.getStatus() == FantasyGame.GameStatus.DRAFTING) {
              try {
-                 nextPickerId = fantasyDraftService.getNextPickInfo(game).pickerId;
+                 FantasyDraftService.NextPickInfo info = fantasyDraftService.getNextPickInfo(game);
+                 nextPickerId = info.pickerId;
+                 round = info.round;
+                 pickInRound = info.pickInRound;
              } catch (Exception e) {
                  // Ignore if calculation fails (e.g. no participants yet)
              }
@@ -262,6 +267,8 @@ public class FantasyGameService {
                 .maxParticipants(game.getMaxParticipants())
                 .nextPickerId(nextPickerId)
                 .nextPickDeadline(game.getNextPickDeadline())
+                .round(round)
+                .pickInRound(pickInRound)
                 .participants(rosterDtos)
                 .build();
     }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -10,9 +10,11 @@ import com.sayai.record.fantasy.repository.FantasyGameRepository;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import com.sayai.record.fantasy.repository.FantasyPlayerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -25,6 +27,8 @@ public class FantasyGameService {
     private final FantasyParticipantRepository fantasyParticipantRepository;
     private final DraftPickRepository draftPickRepository;
     private final FantasyPlayerRepository fantasyPlayerRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final FantasyDraftService fantasyDraftService;
 
     @Transactional(readOnly = true)
     public List<FantasyGameDto> getDashboardGames(Long userId) {
@@ -94,7 +98,7 @@ public class FantasyGameService {
 
     @Transactional
     public FantasyGame createGame(String title, FantasyGame.RuleType ruleType, FantasyGame.ScoringType scoringType,
-                                  String scoringSettings, Integer maxParticipants, java.time.LocalDateTime draftDate, String gameDuration) {
+                                  String scoringSettings, Integer maxParticipants, java.time.LocalDateTime draftDate, String gameDuration, Integer draftTimeLimit) {
         FantasyGame game = FantasyGame.builder()
                 .title(title)
                 .ruleType(ruleType)
@@ -103,6 +107,7 @@ public class FantasyGameService {
                 .maxParticipants(maxParticipants)
                 .draftDate(draftDate)
                 .gameDuration(gameDuration)
+                .draftTimeLimit(draftTimeLimit != null ? draftTimeLimit : 10)
                 .status(FantasyGame.GameStatus.WAITING)
                 .build();
         return fantasyGameRepository.save(game);
@@ -113,6 +118,76 @@ public class FantasyGameService {
         FantasyGame game = fantasyGameRepository.findById(gameSeq)
                 .orElseThrow(() -> new IllegalArgumentException("Game not found"));
         game.setStatus(status);
+    }
+
+    @Transactional
+    public void startGame(Long gameSeq) {
+        FantasyGame game = fantasyGameRepository.findById(gameSeq)
+                .orElseThrow(() -> new IllegalArgumentException("Game not found"));
+
+        if (game.getStatus() != FantasyGame.GameStatus.WAITING) {
+            throw new IllegalStateException("Game must be in WAITING status to start.");
+        }
+
+        List<FantasyParticipant> participants = fantasyParticipantRepository.findByFantasyGameSeq(gameSeq);
+        if (participants.isEmpty()) {
+            throw new IllegalStateException("Cannot start game with no participants.");
+        }
+
+        // Shuffle and assign order
+        Collections.shuffle(participants);
+        for (int i = 0; i < participants.size(); i++) {
+            // Using reflection/setter if no public setter, but entity usually has Lombok Setter?
+            // FantasyParticipant uses @Builder @Getter. No Setter on fields?
+            // It has @NoArgsConstructor(access = AccessLevel.PROTECTED) and @AllArgsConstructor
+            // Ah, I need to check if it has Setters.
+            // If not, I need to update via Repository or add Setter.
+            // Let's assume I can use Reflection or I added setters?
+            // The file content showed: @Getter, @NoArgsConstructor, @AllArgsConstructor, @Builder. No @Setter.
+            // I need to add @Setter to FantasyParticipant or use Builder to rebuild (not optimal for JPA managed).
+            // I'll check if I can add @Setter.
+        }
+        // Wait, I need to add Setter to FantasyParticipant first or update the file.
+        // I will add @Setter to FantasyParticipant in a moment.
+
+        // Assuming Setters exist (I will add them):
+        int order = 1;
+        for (FantasyParticipant p : participants) {
+            p.setDraftOrder(order++);
+        }
+        fantasyParticipantRepository.saveAll(participants);
+
+        // Update Game Status
+        game.setStatus(FantasyGame.GameStatus.DRAFTING);
+
+        // Set Initial Deadline
+        if (game.getDraftTimeLimit() != null && game.getDraftTimeLimit() > 0) {
+            game.setNextPickDeadline(LocalDateTime.now().plusMinutes(game.getDraftTimeLimit()));
+        }
+
+        // Prepare Event Data
+        List<ParticipantRosterDto> orderList = participants.stream()
+            .sorted(Comparator.comparingInt(FantasyParticipant::getDraftOrder))
+            .map(p -> ParticipantRosterDto.builder()
+                .participantId(p.getPlayerId())
+                .teamName(p.getTeamName())
+                .preferredTeam(p.getPreferredTeam())
+                .draftOrder(p.getDraftOrder())
+                .build())
+            .collect(Collectors.toList());
+
+        DraftEventDto event = DraftEventDto.builder()
+                .type("START")
+                .fantasyGameSeq(gameSeq)
+                .message("Draft Started")
+                .draftOrder(orderList)
+                .nextPickerId(orderList.get(0).getParticipantId()) // First picker
+                .nextPickDeadline(game.getNextPickDeadline())
+                .round(1)
+                .pickInRound(1)
+                .build();
+
+        messagingTemplate.convertAndSend("/topic/draft/" + gameSeq, event);
     }
 
     @Transactional(readOnly = true)
@@ -160,6 +235,16 @@ public class FantasyGameService {
         Map<Long, FantasyPlayer> fantasyPlayers = fantasyPlayerRepository.findAllById(fantasyPlayerSeqs).stream()
                 .collect(Collectors.toMap(FantasyPlayer::getSeq, Function.identity()));
 
+        // Calculate Next Picker (if Drafting)
+        Long nextPickerId = null;
+        if (game.getStatus() == FantasyGame.GameStatus.DRAFTING) {
+             try {
+                 nextPickerId = fantasyDraftService.getNextPickInfo(game).pickerId;
+             } catch (Exception e) {
+                 // Ignore if calculation fails (e.g. no participants yet)
+             }
+        }
+
         List<ParticipantRosterDto> rosterDtos = participants.stream().map(p -> {
             List<DraftPick> myPicks = picksByParticipant.getOrDefault(p.getPlayerId(), Collections.emptyList());
             List<FantasyPlayerDto> roster = myPicks.stream()
@@ -173,6 +258,8 @@ public class FantasyGameService {
             return ParticipantRosterDto.builder()
                     .participantId(p.getPlayerId())
                     .teamName(p.getTeamName())
+                    .preferredTeam(p.getPreferredTeam())
+                    .draftOrder(p.getDraftOrder())
                     .roster(roster)
                     .build();
         }).collect(Collectors.toList());
@@ -187,6 +274,8 @@ public class FantasyGameService {
                 .gameDuration(game.getGameDuration())
                 .participantCount(participants.size())
                 .maxParticipants(game.getMaxParticipants())
+                .nextPickerId(nextPickerId)
+                .nextPickDeadline(game.getNextPickDeadline())
                 .participants(rosterDtos)
                 .build();
     }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -136,21 +136,7 @@ public class FantasyGameService {
 
         // Shuffle and assign order
         Collections.shuffle(participants);
-        for (int i = 0; i < participants.size(); i++) {
-            // Using reflection/setter if no public setter, but entity usually has Lombok Setter?
-            // FantasyParticipant uses @Builder @Getter. No Setter on fields?
-            // It has @NoArgsConstructor(access = AccessLevel.PROTECTED) and @AllArgsConstructor
-            // Ah, I need to check if it has Setters.
-            // If not, I need to update via Repository or add Setter.
-            // Let's assume I can use Reflection or I added setters?
-            // The file content showed: @Getter, @NoArgsConstructor, @AllArgsConstructor, @Builder. No @Setter.
-            // I need to add @Setter to FantasyParticipant or use Builder to rebuild (not optimal for JPA managed).
-            // I'll check if I can add @Setter.
-        }
-        // Wait, I need to add Setter to FantasyParticipant first or update the file.
-        // I will add @Setter to FantasyParticipant in a moment.
 
-        // Assuming Setters exist (I will add them):
         int order = 1;
         for (FantasyParticipant p : participants) {
             p.setDraftOrder(order++);

--- a/src/main/java/com/sayai/record/fantasy/service/rules/DraftRuleValidator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/DraftRuleValidator.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface DraftRuleValidator {
     void validate(FantasyGame game, FantasyPlayer newPlayer, List<FantasyPlayer> currentTeam, FantasyParticipant participant);
     FantasyGame.RuleType getSupportedRuleType();
+    int getTotalPlayerCount();
 }

--- a/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
@@ -33,6 +33,11 @@ public class Rule1Validator implements DraftRuleValidator {
         return FantasyGame.RuleType.RULE_1;
     }
 
+    @Override
+    public int getTotalPlayerCount() {
+        return 18;
+    }
+
     protected Map<String, Integer> getRequiredSlots() {
         return BASE_SLOTS;
     }

--- a/src/main/java/com/sayai/record/fantasy/service/rules/Rule2Validator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/Rule2Validator.java
@@ -24,7 +24,14 @@ public class Rule2Validator extends Rule1Validator {
             }
 
             // Normalize team names for comparison if needed
-            if (!participant.getPreferredTeam().equalsIgnoreCase(newPlayer.getTeam())) {
+            // Use contains to support Short Name vs Full Name (e.g., KIA vs KIA Tigers)
+            String pref = participant.getPreferredTeam().trim();
+            String playerTeam = newPlayer.getTeam().trim();
+
+            boolean match = playerTeam.toLowerCase().contains(pref.toLowerCase()) ||
+                            pref.toLowerCase().contains(playerTeam.toLowerCase());
+
+            if (!match) {
                 throw new IllegalStateException("First pick must be from preferred team: " + participant.getPreferredTeam());
             }
         }

--- a/src/main/resources/static/css/fantasy.css
+++ b/src/main/resources/static/css/fantasy.css
@@ -317,7 +317,7 @@
 
 .pos-lf { top: 20%; left: 15%; }
 .pos-cf { top: 5%; left: 50%; transform: translate(-50%, 0); }
-.pos-rf { top: 20%; right: 15%; }
+.pos-rf { top: 30%; right: 0%; }
 
 .pos-dh { bottom: 10%; right: 5%; }
 .pos-p { display: none; } /* Hide if any script tries to use it */

--- a/src/main/resources/static/css/fantasy.css
+++ b/src/main/resources/static/css/fantasy.css
@@ -160,6 +160,27 @@
     border: 1px solid #ccc;
 }
 
+@media (max-width: 576px) {
+    .baseball-field {
+        height: 400px; /* Shrink height on small mobile */
+        border-radius: 8px 8px 50px 50px;
+    }
+    .field-position {
+        width: 70px; /* Shrink cards */
+        padding: 2px;
+    }
+    .field-position .pos-label {
+        font-size: 0.6rem;
+    }
+    .field-position .player-name {
+        font-size: 0.7rem;
+    }
+    .field-position .player-team {
+        font-size: 0.6rem;
+        display: none; /* Hide team name to save space if needed */
+    }
+}
+
 .field-position .pos-label {
     display: block;
     font-weight: bold;
@@ -234,6 +255,8 @@
     background-color: #fff;
     border-bottom: 1px solid #ddd;
     margin-bottom: 20px;
+    overflow-x: auto; /* Enable horizontal scroll on mobile */
+    -webkit-overflow-scrolling: touch;
 }
 .fantasy-nav {
     display: flex;
@@ -242,6 +265,8 @@
     margin: 0;
     justify-content: flex-start;
     border-bottom: 1px solid #eee;
+    white-space: nowrap; /* Prevent wrapping */
+    min-width: min-content; /* Ensure width fits content */
 }
 .fantasy-nav li {
     margin: 0;

--- a/src/main/resources/static/css/fantasy.css
+++ b/src/main/resources/static/css/fantasy.css
@@ -317,7 +317,7 @@
 
 .pos-lf { top: 20%; left: 15%; }
 .pos-cf { top: 5%; left: 50%; transform: translate(-50%, 0); }
-.pos-rf { top: 30%; right: 0%; }
+.pos-rf { top: 20%; right: 0%; }
 
 .pos-dh { bottom: 10%; right: 5%; }
 .pos-p { display: none; } /* Hide if any script tries to use it */

--- a/src/main/resources/templates/admin/game-create.html
+++ b/src/main/resources/templates/admin/game-create.html
@@ -9,8 +9,8 @@
         Title: <input type="text" name="title"><br>
         Rule Type:
         <select name="ruleType">
-            <option value="RULE_1">Rule 1 (Roster)</option>
-            <option value="RULE_2">Rule 2 (Preferred Team)</option>
+            <option value="RULE_1">Rule 1 (Normal)</option>
+            <option value="RULE_2">Rule 2 (1차 지명룰)</option>
         </select><br>
         Scoring Type:
         <select name="scoringType">

--- a/src/main/resources/templates/fantasy/admin.html
+++ b/src/main/resources/templates/fantasy/admin.html
@@ -120,6 +120,16 @@
             });
         }
 
+        function startDraft(gameSeq) {
+            if(!confirm("Start the draft for Game #" + gameSeq + "?")) return;
+            $.post(`/apis/v1/fantasy/games/${gameSeq}/start`, function() {
+                alert("Draft Started!");
+                loadGames();
+            }).fail(function(xhr) {
+                alert("Failed to start: " + (xhr.responseText || 'Error'));
+            });
+        }
+
         function loadGames() {
             $.get('/apis/v1/fantasy/games', function(games) {
                 const tbody = $('#gameListBody');
@@ -145,6 +155,7 @@
                                         <option value="FINISHED" ${game.status === 'FINISHED' ? 'selected' : ''}>FINISHED</option>
                                     </select>
                                     <button onclick="updateStatus(${game.seq})" class="btn-draft">Update</button>
+                                    ${game.status === 'WAITING' ? `<button onclick="startDraft(${game.seq})" class="btn-primary" style="margin-left: 10px;">Start Draft</button>` : ''}
                                 </div>
                             </td>
                         </tr>

--- a/src/main/resources/templates/fantasy/admin.html
+++ b/src/main/resources/templates/fantasy/admin.html
@@ -74,6 +74,10 @@
                         <input type="datetime-local" name="draftDate" class="form-control" required style="width: 100%; padding: 8px;">
                     </div>
                     <div class="form-group" style="margin-bottom: 15px;">
+                        <label style="font-weight: bold;">Draft Time Limit (Minutes)</label>
+                        <input type="number" name="draftTimeLimit" class="form-control" value="10" style="width: 100%; padding: 8px;">
+                    </div>
+                    <div class="form-group" style="margin-bottom: 15px;">
                         <label style="font-weight: bold;">Game Period (Start ~ End)</label>
                         <div style="display: flex; gap: 10px;">
                             <input type="date" id="durationStart" class="form-control" style="flex: 1; padding: 8px;">
@@ -169,6 +173,7 @@
                     scoringType: $('select[name="scoringType"]').val(),
                     maxParticipants: $('input[name="maxParticipants"]').val(),
                     draftDate: $('input[name="draftDate"]').val(),
+                    draftTimeLimit: $('input[name="draftTimeLimit"]').val(),
                     gameDuration: durationStr,
                     scoringSettings: $('textarea[name="scoringSettings"]').val()
                 };

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -63,9 +63,6 @@
             </div>
         </div>
 
-        <div id="admin-controls" sec:authorize="hasRole('ADMIN')" style="margin-bottom: 15px;">
-            <button id="btn-start-draft" class="btn-primary" onclick="startDraft()">Start Draft</button>
-        </div>
 
         <div class="draft-container">
             <!-- Available Players -->
@@ -252,14 +249,6 @@
             }
         }
 
-        function startDraft() {
-            if(!confirm("Start the draft?")) return;
-            $.post(`/apis/v1/fantasy/games/${gameSeq}/start`, function() {
-                // Success
-            }).fail(function(xhr) {
-                alert("Failed to start: " + xhr.responseText);
-            });
-        }
 
         function connectWebSocket() {
             const socket = new SockJS('/ws');

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -7,6 +7,42 @@
     <link rel="stylesheet" th:href="@{/css/fantasy.css}">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.6.1/sockjs.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <style>
+        .draft-order-strip {
+            display: flex;
+            overflow-x: auto;
+            background: #eee;
+            padding: 10px;
+            margin-bottom: 10px;
+            border-radius: 5px;
+            gap: 10px;
+        }
+        .draft-participant {
+            padding: 5px 10px;
+            background: white;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            white-space: nowrap;
+        }
+        .draft-participant.active {
+            background: #007bff;
+            color: white;
+            font-weight: bold;
+            border-color: #0056b3;
+        }
+        .draft-info-bar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: #f8f9fa;
+            padding: 10px;
+            margin-bottom: 10px;
+            border-radius: 5px;
+            border: 1px solid #ddd;
+        }
+        .timer { font-weight: bold; color: #d9534f; }
+        .disabled-btn { opacity: 0.5; cursor: not-allowed; }
+    </style>
 </head>
 <body>
 <div layout:fragment="content">
@@ -18,7 +54,21 @@
 
         <div th:replace="fragments/fantasy-nav :: nav(active='draft')"></div>
 
+        <div id="draft-ui-container" style="display:none;">
+            <div id="draft-order-strip" class="draft-order-strip"></div>
+            <div class="draft-info-bar">
+                <span>Round: <span id="current-round">-</span></span>
+                <span>Turn: <strong id="current-turn-name">-</strong></span>
+                <span>Time Left: <span id="timer" class="timer">--:--</span></span>
+            </div>
+        </div>
+
+        <div id="admin-controls" style="margin-bottom: 15px; display: none;">
+            <button id="btn-start-draft" class="btn-primary" onclick="startDraft()">Start Draft</button>
+        </div>
+
         <div class="draft-container">
+            <!-- Available Players -->
             <div class="fantasy-card">
                 <h2 class="card-title">Available Players</h2>
                 <div style="margin-bottom: 10px; display: flex; gap: 10px; flex-wrap: wrap;">
@@ -71,6 +121,7 @@
                 </div>
             </div>
 
+            <!-- My Picks -->
             <div class="fantasy-card">
                 <h2 class="card-title">My Picks</h2>
                 <ul id="my-picks-list" style="list-style: none; padding: 0;">
@@ -90,10 +141,20 @@
         const userId = document.getElementById('currentUserId').value;
         let stompClient = null;
 
+        // Game State
+        let gameState = {
+            status: 'WAITING',
+            participants: [],
+            nextPickerId: null,
+            nextPickDeadline: null,
+            ruleType: 'RULE_1',
+            myPreferredTeam: null,
+            round: 1 // Default
+        };
+
         $(document).ready(function() {
+            initGame();
             connectWebSocket();
-            loadAvailablePlayers();
-            loadMyPicks();
 
             $('#filter-team, #filter-position').change(function() {
                 loadAvailablePlayers();
@@ -102,14 +163,105 @@
                 if (e.key === 'Enter') loadAvailablePlayers();
             });
 
-            $('#game-status').text('DRAFTING').removeClass('status-WAITING').addClass('status-DRAFTING');
+            setInterval(updateTimer, 1000);
         });
+
+        function initGame() {
+            $.get(`/apis/v1/fantasy/games/${gameSeq}/details`, function(data) {
+                gameState.status = data.status;
+                gameState.participants = data.participants || [];
+                gameState.nextPickerId = data.nextPickerId;
+                gameState.nextPickDeadline = data.nextPickDeadline;
+                gameState.ruleType = data.ruleType; // RULE_1 or RULE_2
+
+                // Determine My Info
+                const myPart = gameState.participants.find(p => String(p.participantId) === String(userId));
+                if (myPart) {
+                    gameState.myPreferredTeam = myPart.preferredTeam;
+                }
+
+                // Determine Round: Backend doesn't send round in details yet, default 1 or calculate if needed.
+                // For MVP, if picking events happen, round will update.
+                updateUI();
+                loadAvailablePlayers();
+                loadMyPicks();
+            });
+        }
+
+        function updateUI() {
+            // Update Status Badge
+            $('#game-status').text(gameState.status).attr('class', 'status-badge status-' + gameState.status);
+
+            // Show/Hide Admin Controls
+            if (gameState.status === 'WAITING') {
+                $('#admin-controls').show();
+                $('#draft-ui-container').hide();
+            } else if (gameState.status === 'DRAFTING') {
+                $('#admin-controls').hide();
+                $('#draft-ui-container').show();
+            } else {
+                $('#admin-controls').hide();
+                $('#draft-ui-container').hide();
+            }
+
+            renderOrderStrip();
+
+            // Highlight Current Turn
+            if (gameState.nextPickerId) {
+                const picker = gameState.participants.find(p => p.participantId === gameState.nextPickerId);
+                $('#current-turn-name').text(picker ? picker.teamName : 'Unknown');
+                $('#current-round').text(gameState.round || '-');
+            }
+        }
+
+        function renderOrderStrip() {
+            const strip = $('#draft-order-strip');
+            strip.empty();
+
+            // Sort by draftOrder
+            const sorted = [...gameState.participants].sort((a, b) => (a.draftOrder || 0) - (b.draftOrder || 0));
+
+            sorted.forEach(p => {
+                const isActive = (p.participantId === gameState.nextPickerId);
+                strip.append(`
+                    <div class="draft-participant ${isActive ? 'active' : ''}">
+                        ${p.draftOrder}. ${p.teamName}
+                    </div>
+                `);
+            });
+        }
+
+        function updateTimer() {
+            if (gameState.status !== 'DRAFTING' || !gameState.nextPickDeadline) {
+                $('#timer').text('--:--');
+                return;
+            }
+            const now = new Date().getTime();
+            const deadline = new Date(gameState.nextPickDeadline).getTime();
+            const diff = deadline - now;
+
+            if (diff <= 0) {
+                $('#timer').text('00:00');
+            } else {
+                const min = Math.floor(diff / 60000);
+                const sec = Math.floor((diff % 60000) / 1000);
+                $('#timer').text(`${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`);
+            }
+        }
+
+        function startDraft() {
+            if(!confirm("Start the draft?")) return;
+            $.post(`/apis/v1/fantasy/games/${gameSeq}/start`, function() {
+                // Success
+            }).fail(function(xhr) {
+                alert("Failed to start: " + xhr.responseText);
+            });
+        }
 
         function connectWebSocket() {
             const socket = new SockJS('/ws');
             stompClient = Stomp.over(socket);
             stompClient.connect({}, function(frame) {
-                console.log('Connected: ' + frame);
                 stompClient.subscribe('/topic/draft/' + gameSeq, function(message) {
                     const event = JSON.parse(message.body);
                     handleDraftEvent(event);
@@ -118,9 +270,23 @@
         }
 
         function handleDraftEvent(event) {
-            loadAvailablePlayers();
-            if (String(event.playerId) === String(userId)) {
-                loadMyPicks();
+            if (event.type === 'START') {
+                gameState.status = 'DRAFTING';
+                gameState.participants = event.draftOrder; // Update with ordered list
+                gameState.nextPickerId = event.nextPickerId;
+                gameState.nextPickDeadline = event.nextPickDeadline;
+                gameState.round = event.round;
+                updateUI();
+                loadAvailablePlayers();
+            } else if (event.type === 'PICK') {
+                gameState.nextPickerId = event.nextPickerId;
+                gameState.nextPickDeadline = event.nextPickDeadline;
+                gameState.round = event.round;
+                updateUI();
+                loadAvailablePlayers();
+                if (String(event.playerId) === String(userId)) {
+                    loadMyPicks();
+                }
             }
         }
 
@@ -137,15 +303,30 @@
             $.get(`/apis/v1/fantasy/games/${gameSeq}/available-players${query}`, function(data) {
                 const tbody = $('#available-players-body');
                 tbody.empty();
+
+                const isMyTurn = (String(gameState.nextPickerId) === String(userId));
+                const isRound1 = (gameState.round === 1);
+
                 data.forEach(player => {
                     const firstPos = player.position ? player.position.split(',')[0].trim().toLowerCase() : '';
-                    const posClass = 'pos-' + firstPos;
-                    // 'CL' -> 'pos-cp' mapping for color consistency if needed, but CSS has 'pos-cl' if I add it, or map here.
-                    // CSS has .pos-cp. Let's map CL to CP if needed or add .pos-cl to CSS.
-                    // Wait, I didn't add .pos-cl. I added .pos-cp.
-                    // I'll check player.position values. If it's 'CL', I should use 'pos-cp'.
-                    let cssClass = posClass;
+                    let cssClass = 'pos-' + firstPos;
                     if(firstPos === 'cl') cssClass = 'pos-cp';
+
+                    let disabled = !isMyTurn;
+                    let btnText = "Draft";
+
+                    // Rule 2 Check
+                    if (isMyTurn && gameState.ruleType === 'RULE_2' && isRound1) {
+                         // Check team
+                         const myTeam = (gameState.myPreferredTeam || "").toLowerCase().trim();
+                         const pTeam = (player.team || "").toLowerCase().trim();
+                         if (myTeam && !pTeam.includes(myTeam) && !myTeam.includes(pTeam)) {
+                             disabled = true;
+                             btnText = "Restricted"; // Or just keep disabled
+                         }
+                    }
+
+                    // Also disable if already picked (API should filter, but double check handled by disabled Draft button logic if needed, but API filters already)
 
                     tbody.append(`
                         <tr>
@@ -153,7 +334,13 @@
                             <td><span class="position-badge ${cssClass}">${player.position}</span></td>
                             <td><span class="team-badge">${player.team}</span></td>
                             <td>${player.stats || '-'}</td>
-                            <td><button class="btn-draft" onclick="draftPlayer(${player.seq})">Draft</button></td>
+                            <td>
+                                <button class="btn-draft ${disabled ? 'disabled-btn' : ''}"
+                                        onclick="draftPlayer(${player.seq})"
+                                        ${disabled ? 'disabled' : ''}>
+                                    ${btnText}
+                                </button>
+                            </td>
                         </tr>
                     `);
                 });

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -63,7 +63,7 @@
             </div>
         </div>
 
-        <div id="admin-controls" style="margin-bottom: 15px; display: none;">
+        <div id="admin-controls" sec:authorize="hasRole('ADMIN')" style="margin-bottom: 15px; display: none;">
             <button id="btn-start-draft" class="btn-primary" onclick="startDraft()">Start Draft</button>
         </div>
 

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -63,7 +63,7 @@
             </div>
         </div>
 
-        <div id="admin-controls" sec:authorize="hasRole('ADMIN')" style="margin-bottom: 15px; display: none;">
+        <div id="admin-controls" sec:authorize="hasRole('ADMIN')" style="margin-bottom: 15px;">
             <button id="btn-start-draft" class="btn-primary" onclick="startDraft()">Start Draft</button>
         </div>
 
@@ -194,7 +194,10 @@
 
             // Show/Hide Admin Controls
             if (gameState.status === 'WAITING') {
-                $('#admin-controls').show();
+                // Only show if element exists (admin only)
+                if ($('#admin-controls').length) {
+                   $('#admin-controls').show();
+                }
                 $('#draft-ui-container').hide();
             } else if (gameState.status === 'DRAFTING') {
                 $('#admin-controls').hide();

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -279,6 +279,16 @@
                 if (String(event.playerId) === String(userId)) {
                     loadMyPicks();
                 }
+            } else if (event.type === 'FINISH') {
+                gameState.status = 'FINISHED'; // Or ONGOING
+                gameState.nextPickerId = null;
+                gameState.nextPickDeadline = null;
+                alert("Draft Completed!");
+                updateUI();
+                loadAvailablePlayers();
+                if (String(event.playerId) === String(userId)) {
+                    loadMyPicks();
+                }
             }
         }
 

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -67,13 +67,13 @@
         <div class="draft-container">
             <!-- Available Players -->
             <div class="fantasy-card">
-                <h2 class="card-title">Available Players</h2>
+                <h2 class="card-title">선수 목록</h2>
                 <div style="margin-bottom: 10px; display: flex; gap: 10px; flex-wrap: wrap;">
                     <select id="filter-team" style="padding: 5px;">
                         <option value="">모든 팀</option>
                         <option value="두산">두산 베어스</option>
                         <option value="LG">LG 트윈스</option>
-                        <option value="Kia">KIA 타이거즈</option>
+                        <option value="KIA">KIA 타이거즈</option>
                         <option value="삼성">삼성 라이온즈</option>
                         <option value="롯데">롯데 자이언츠</option>
                         <option value="한화">한화 이글스</option>
@@ -170,6 +170,7 @@
                 gameState.nextPickerId = data.nextPickerId;
                 gameState.nextPickDeadline = data.nextPickDeadline;
                 gameState.ruleType = data.ruleType; // RULE_1 or RULE_2
+                gameState.round = data.roundNum;
 
                 // Determine My Info
                 const myPart = gameState.participants.find(p => String(p.participantId) === String(userId));
@@ -383,7 +384,7 @@
                     console.log("Draft request sent successfully");
                 },
                 error: function(xhr) {
-                    alert('Draft Failed: ' + (xhr.responseText || 'Error'));
+                    alert('Draft 실패: ' + (xhr.responseText || 'Error'));
                 }
             });
         }

--- a/src/main/resources/templates/fantasy/index.html
+++ b/src/main/resources/templates/fantasy/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns="http://www.w3.org/1999/html"
+      xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html"
       layout:decorate="~{layout/default}">
 <head>
     <title>Fantasy League - Dashboard</title>
@@ -35,18 +36,23 @@
                     <h3>Rules & Scoring</h3>
                     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
                         <div>
-                            <p><strong>Rule Type:</strong> <span id="detailRule"></span></p>
-                            <p><strong>Scoring:</strong> <span id="detailScoring"></span></p>
-                            <p><strong>Status:</strong> <span id="detailStatus"></span></p>
-                            <p><strong>Period:</strong> <span id="detailDuration"></span></p>
+                            <p><strong>드래프트룰:</strong> <span id="detailRule"></span></p>
+                            <p><strong>배점 방식:</strong> <span id="detailScoring"></span></p>
+                            <p><strong>상태:</strong> <span id="detailStatus"></span></p>
+                            <p><strong>대회 기간:</strong> <span id="detailDuration"></span></p>
                         </div>
                         <div>
-                            <p><strong>Scoring Settings:</strong></p>
+                            <p><strong>배점 방식:</strong></p>
                             <div id="detailScoringSettings" style="background: #f9f9f9; padding: 10px; border-radius: 4px; font-size: 0.9rem; max-height: 100px; overflow-y: auto;"></div>
                         </div>
                     </div>
                     <p style="margin-top: 10px; color: #666; font-style: italic;">
-                        (Description of the specific rule type will appear here...)
+                        <br> 1. ㄹ 자 드래프트로 18인 픽 (타자 9 / 투수 9) </br>
+                        <br> 2. 배점 방식: 한주간 성적의 종합으로 순위 매김 (로티세리 룰) </br>
+                        <br> 3. 선수단 성적 별로 타자 5개 종목, 투수 5개 종목의 순위에 따라 점수를 받아서 4주간 총점이 높은자가 우승 </br>
+                        <br> 4. 타자부문 타율 홈런 타점 삼진 도루 </br>
+                        <br> 투수부문 다승 탈삼진 세이브 방어율 whip </br>
+                        <br> 5. 드래프트 Rule_2의 경우 1차 지명 룰이 존재 (응원팀의 선수만 1라운드 픽 가능) </br>
                     </p>
                 </div>
 
@@ -110,25 +116,25 @@
                 <form id="joinForm">
                     <input type="hidden" id="joinGameSeq">
                     <div class="form-group" style="margin-bottom: 15px;">
-                        <label style="display:block; margin-bottom: 5px; font-weight: bold;">My Team Name</label>
+                        <label style="display:block; margin-bottom: 5px; font-weight: bold;">팀명</label>
                         <input type="text" id="joinTeamName" class="form-control" required placeholder="Enter your fantasy team name" style="width: 100%; padding: 8px;">
                     </div>
                     <div class="form-group" style="margin-bottom: 15px;">
-                        <label style="display:block; margin-bottom: 5px; font-weight: bold;">Preferred KBO Team</label>
+                        <label style="display:block; margin-bottom: 5px; font-weight: bold;">응원팀을 고르세요</label>
                         <select id="joinPrefTeam" class="form-control" style="width: 100%; padding: 8px;">
-                            <option value="KIA">KIA Tigers</option>
-                            <option value="SAMSUNG">Samsung Lions</option>
-                            <option value="LG">LG Twins</option>
-                            <option value="DOOSAN">Doosan Bears</option>
-                            <option value="KT">KT Wiz</option>
-                            <option value="SSG">SSG Landers</option>
-                            <option value="LOTTE">Lotte Giants</option>
-                            <option value="HANWHA">Hanwha Eagles</option>
-                            <option value="NC">NC Dinos</option>
-                            <option value="KIWOOM">Kiwoom Heroes</option>
+                            <option value="KIA">KIA 타이거즈</option>
+                            <option value="삼성">삼성 라이온즈</option>
+                            <option value="LG">LG 트윈스</option>
+                            <option value="두산">두산 베어스</option>
+                            <option value="KT">KT 위즈</option>
+                            <option value="SSG">SSG 랜더스</option>
+                            <option value="롯데">롯데 자이언츠</option>
+                            <option value="한화">한화 이글스</option>
+                            <option value="NC">NC 다이노스</option>
+                            <option value="키움">키움 히어로즈</option>
                         </select>
                     </div>
-                    <button type="submit" class="btn btn-primary" style="width: 100%; padding: 10px;">Join League</button>
+                    <button type="submit" class="btn btn-primary" style="width: 100%; padding: 10px;">참가하기</button>
                 </form>
             </div>
         </div>
@@ -197,11 +203,11 @@
                     const card = `
                         <div class="fantasy-card" style="border: 1px solid #ddd; padding: 20px; border-radius: 8px; background: #fff;">
                             <h3 style="margin-top:0; border-bottom: 2px solid #eee; padding-bottom: 10px;">${game.title}</h3>
-                            <p><strong>Rule:</strong> ${game.ruleType}</p>
-                            <p><strong>Scoring:</strong> ${game.scoringType}</p>
-                            <p><strong>Participants:</strong> ${game.participantCount} / ${game.maxParticipants || 'Unlim.'}</p>
-                            <p><strong>Draft Date:</strong> ${game.draftDate ? new Date(game.draftDate).toLocaleString() : 'TBD'}</p>
-                            <p><strong>Period:</strong> ${game.gameDuration || 'TBD'}</p>
+                            <p><strong>드래프트룰:</strong> ${game.ruleType}</p>
+                            <p><strong>배점 방식:</strong> ${game.scoringType}</p>
+                            <p><strong>참가자수:</strong> ${game.participantCount} / ${game.maxParticipants || 'Unlim.'}</p>
+                            <p><strong>드래프트 일정:</strong> ${game.draftDate ? new Date(game.draftDate).toLocaleString() : 'TBD'}</p>
+                            <p><strong>대회 일정:</strong> ${game.gameDuration || 'TBD'}</p>
                             <div style="margin-top: 15px;">
                                 ${actionBtn}
                                 <button class="btn btn-secondary" style="width:100%; margin-top:5px; background:#6c757d; color:white; border:none; padding:8px 16px; border-radius:4px; cursor:pointer;" onclick="openDetailsModal(${game.seq})">Details</button>

--- a/src/test/java/com/sayai/record/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/sayai/record/admin/controller/AdminControllerTest.java
@@ -1,7 +1,8 @@
 package com.sayai.record.admin.controller;
 
+import com.sayai.record.auth.repository.MemberRepository;
 import com.sayai.record.fantasy.entity.FantasyGame;
-import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import com.sayai.record.fantasy.service.FantasyGameService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,7 +18,10 @@ import static org.mockito.Mockito.when;
 class AdminControllerTest {
 
     @Mock
-    private FantasyGameRepository fantasyGameRepository;
+    private FantasyGameService fantasyGameService;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     @InjectMocks
     private AdminController adminController;
@@ -29,7 +33,12 @@ class AdminControllerTest {
         req.setRuleType(FantasyGame.RuleType.RULE_1);
         req.setScoringType(FantasyGame.ScoringType.POINTS);
 
-        when(fantasyGameRepository.save(any(FantasyGame.class))).thenAnswer(i -> i.getArguments()[0]);
+        when(fantasyGameService.createGame(
+                any(), any(), any(), any(), any(), any(), any(), any()
+        )).thenReturn(FantasyGame.builder()
+                .title("New League")
+                .scoringType(FantasyGame.ScoringType.POINTS)
+                .build());
 
         ResponseEntity<FantasyGame> response = adminController.createGame(req);
 

--- a/src/test/java/com/sayai/record/fantasy/api/FantasyApiTest.java
+++ b/src/test/java/com/sayai/record/fantasy/api/FantasyApiTest.java
@@ -2,10 +2,13 @@ package com.sayai.record.fantasy.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sayai.record.admin.controller.AdminController;
+import com.sayai.record.auth.entity.Member;
+import com.sayai.record.auth.repository.MemberRepository;
 import com.sayai.record.fantasy.controller.FantasyDraftController;
 import com.sayai.record.fantasy.entity.FantasyGame;
 import com.sayai.record.fantasy.repository.FantasyGameRepository;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,6 +36,23 @@ public class FantasyApiTest {
 
     @Autowired
     private FantasyGameRepository fantasyGameRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    public void setup() {
+        if (memberRepository.findByUserId("user").isEmpty()) {
+            Member member = Member.builder()
+                    .userId("user")
+                    .password("pass")
+                    .name("Test User")
+                    .role(Member.Role.USER)
+                    .playerId(1L)
+                    .build();
+            memberRepository.save(member);
+        }
+    }
 
     @Test
     @WithMockUser(username = "admin", roles = {"ADMIN"})

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true


### PR DESCRIPTION
- Added `Start Draft` logic with randomized participant order.
- Implemented Snake Draft ordering (1-N, N-1).
- Implemented Rule 2 (Preferred Team restriction for Round 1).
- Added Auto-Pick functionality with Rule validation.
- Added `DraftScheduler` to enforce time limits (default 10 mins).
- Updated Frontend (`draft.html`) to show Order, Timer, Turn info, and restrict buttons.
- Updated `FantasyGame`, `FantasyParticipant` entities and DTOs.
- Fixed `FantasyApiTest` by adding `Member` seeding and `H2` dependency for tests.

---
*PR created automatically by Jules for task [2794947193954836678](https://jules.google.com/task/2794947193954836678) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-triggered draft start endpoint, configurable draft time limit, scheduled automatic picks on timeout, and Start Draft button in admin UI.

* **Improvements**
  * Live draft UI with countdown, draft order strip, per-turn controls, richer real-time state (next picker, deadline, round, order), participant preferred team and draft order, relaxed team-match rule, and mobile CSS tweaks.

* **Tests**
  * H2 in-memory test DB and test setup added.

* **Chores**
  * Template security integration and scheduling enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->