### PR TITLE
Fix TemplateInputException in Fantasy Dashboard

### DIFF
--- a/src/main/resources/templates/fantasy/index.html
+++ b/src/main/resources/templates/fantasy/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns="http://www.w3.org/1999/html"
-      xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/default}">
 <head>
     <title>Fantasy League - Dashboard</title>

--- a/src/test/java/com/sayai/record/fantasy/controller/FantasyViewControllerTest.java
+++ b/src/test/java/com/sayai/record/fantasy/controller/FantasyViewControllerTest.java
@@ -1,0 +1,33 @@
+package com.sayai.record.fantasy.controller;
+
+import com.sayai.record.auth.repository.MemberRepository;
+import com.sayai.record.fantasy.service.FantasyGameService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FantasyViewController.class)
+class FantasyViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FantasyGameService fantasyGameService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @WithMockUser
+    void dashboard_shouldRenderTemplate() throws Exception {
+        mockMvc.perform(get("/fantasy"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
Removed duplicate xmlns attributes from templates/fantasy/index.html to resolve TemplateInputException. Added FantasyViewControllerTest to verify template rendering.

---
*PR created automatically by Jules for task [7278863068182228475](https://jules.google.com/task/7278863068182228475) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the fantasy dashboard endpoint to verify successful HTTP responses.

* **Chores**
  * Updated XML namespace declarations in the frontend template for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->