### PR TITLE
Optimize DraftScheduler to run only when drafting games exist

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/repository/FantasyGameRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/FantasyGameRepository.java
@@ -12,4 +12,6 @@ public interface FantasyGameRepository extends JpaRepository<FantasyGame, Long> 
 
     @Query("SELECT g FROM FantasyGame g WHERE g.status = :status AND g.draftTimeLimit > 0 AND g.nextPickDeadline < :now")
     List<FantasyGame> findExpiredDraftingGames(@Param("status") FantasyGame.GameStatus status, @Param("now") LocalDateTime now);
+
+    List<FantasyGame> findAllByStatus(FantasyGame.GameStatus status);
 }

--- a/src/main/java/com/sayai/record/fantasy/service/DraftScheduler.java
+++ b/src/main/java/com/sayai/record/fantasy/service/DraftScheduler.java
@@ -2,6 +2,7 @@ package com.sayai.record.fantasy.service;
 
 import com.sayai.record.fantasy.entity.FantasyGame;
 import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -19,8 +22,29 @@ public class DraftScheduler {
     private final FantasyGameRepository fantasyGameRepository;
     private final FantasyDraftService fantasyDraftService;
 
+    private final Set<Long> activeGameSeqs = ConcurrentHashMap.newKeySet();
+
+    @PostConstruct
+    public void init() {
+        List<FantasyGame> draftingGames = fantasyGameRepository.findAllByStatus(FantasyGame.GameStatus.DRAFTING);
+        activeGameSeqs.addAll(draftingGames.stream().map(FantasyGame::getSeq).collect(Collectors.toList()));
+        log.info("DraftScheduler initialized with {} active drafting games.", activeGameSeqs.size());
+    }
+
+    public void addActiveGame(Long gameSeq) {
+        activeGameSeqs.add(gameSeq);
+    }
+
+    public void removeActiveGame(Long gameSeq) {
+        activeGameSeqs.remove(gameSeq);
+    }
+
     @Scheduled(fixedRate = 10000) // Check every 10 seconds
     public void checkDraftTimeouts() {
+        if (activeGameSeqs.isEmpty()) {
+            return;
+        }
+
         // Find DRAFTING games with deadline < NOW and timeLimit > 0
         List<FantasyGame> draftingGames = fantasyGameRepository.findExpiredDraftingGames(FantasyGame.GameStatus.DRAFTING, LocalDateTime.now());
 

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceDraftSchedulerTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceDraftSchedulerTest.java
@@ -1,0 +1,76 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FantasyGameServiceDraftSchedulerTest {
+
+    @Mock private FantasyGameRepository fantasyGameRepository;
+    @Mock private FantasyParticipantRepository fantasyParticipantRepository;
+    @Mock private DraftScheduler draftScheduler;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private FantasyGameService fantasyGameService;
+
+    @Test
+    void startGame_AddsActiveGameToScheduler() {
+        Long gameSeq = 1L;
+        FantasyGame game = FantasyGame.builder()
+                .seq(gameSeq)
+                .status(FantasyGame.GameStatus.WAITING)
+                .draftTimeLimit(10)
+                .build();
+
+        when(fantasyGameRepository.findById(gameSeq)).thenReturn(Optional.of(game));
+        when(fantasyParticipantRepository.findByFantasyGameSeq(gameSeq)).thenReturn(List.of(mock(com.sayai.record.fantasy.entity.FantasyParticipant.class)));
+
+        fantasyGameService.startGame(gameSeq);
+
+        verify(draftScheduler).addActiveGame(gameSeq);
+    }
+
+    @Test
+    void updateGameStatus_AddsToScheduler_WhenDrafting() {
+        Long gameSeq = 1L;
+        FantasyGame game = FantasyGame.builder()
+                .seq(gameSeq)
+                .status(FantasyGame.GameStatus.WAITING)
+                .build();
+
+        when(fantasyGameRepository.findById(gameSeq)).thenReturn(Optional.of(game));
+
+        fantasyGameService.updateGameStatus(gameSeq, FantasyGame.GameStatus.DRAFTING);
+
+        verify(draftScheduler).addActiveGame(gameSeq);
+    }
+
+    @Test
+    void updateGameStatus_RemovesFromScheduler_WhenNotDrafting() {
+        Long gameSeq = 1L;
+        FantasyGame game = FantasyGame.builder()
+                .seq(gameSeq)
+                .status(FantasyGame.GameStatus.DRAFTING)
+                .build();
+
+        when(fantasyGameRepository.findById(gameSeq)).thenReturn(Optional.of(game));
+
+        fantasyGameService.updateGameStatus(gameSeq, FantasyGame.GameStatus.ONGOING);
+
+        verify(draftScheduler).removeActiveGame(gameSeq);
+    }
+}


### PR DESCRIPTION
This PR optimizes the `DraftScheduler` to reduce database load and log noise.

Changes:
1.  **DraftScheduler**: Now maintains a `Set<Long> activeGameSeqs`.
    *   The `@Scheduled` task returns immediately if this set is empty.
    *   `@PostConstruct` initializes the set from the DB on startup.
2.  **FantasyGameService**:
    *   When a game starts or status changes to DRAFTING, it adds the ID to the scheduler.
    *   When status changes away from DRAFTING, it removes the ID.
    *   Updates are wrapped in `TransactionSynchronizationManager.registerSynchronization` to execute only after the transaction commits, preventing state desynchronization.
3.  **FantasyDraftService**:
    *   When a draft finishes (status -> ONGOING), it removes the ID from the scheduler (also transaction-safe).
    *   Uses `ObjectProvider<DraftScheduler>` to break the circular dependency.
4.  **FantasyGameRepository**: Added `findAllByStatus` method.

Verified with `./gradlew test` including new unit tests for the interaction logic.

---
*PR created automatically by Jules for task [8680448301277055816](https://jules.google.com/task/8680448301277055816) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Draft session management now includes active game tracking to optimize performance and scheduling accuracy during draft operations.
  * Improved transaction handling for draft lifecycle management ensures reliable state synchronization across game status changes.

* **Tests**
  * Added comprehensive unit test coverage for draft scheduling interactions, including game activation, removal, and status transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->