### PR TITLE
Add Member Info and Password Change Feature

### DIFF
--- a/src/main/java/com/sayai/record/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sayai/record/auth/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         .requestMatchers("/apis/v1/admin/**").hasRole("ADMIN")
                         // Require auth for Fantasy APIs and Views
                         .requestMatchers("/apis/v1/fantasy/**", "/fantasy/**").authenticated()
+                        .requestMatchers("/apis/v1/auth/password").authenticated()
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(e -> e

--- a/src/main/java/com/sayai/record/auth/controller/AuthController.java
+++ b/src/main/java/com/sayai/record/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package com.sayai.record.auth.controller;
 
+import com.sayai.record.auth.jwt.CustomUserDetails;
 import com.sayai.record.auth.service.AuthService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,6 +59,24 @@ public class AuthController {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
+    }
+
+    @PostMapping("/password")
+    public ResponseEntity<String> changePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ChangePasswordRequest request) {
+        try {
+            authService.changePassword(userDetails.getPlayerId(), request.getCurrentPassword(), request.getNewPassword());
+            return ResponseEntity.ok("Password changed successfully");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @Data
+    public static class ChangePasswordRequest {
+        private String currentPassword;
+        private String newPassword;
     }
 
     @Data

--- a/src/main/java/com/sayai/record/auth/controller/AuthController.java
+++ b/src/main/java/com/sayai/record/auth/controller/AuthController.java
@@ -65,6 +65,9 @@ public class AuthController {
     public ResponseEntity<String> changePassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody ChangePasswordRequest request) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).build();
+        }
         try {
             authService.changePassword(userDetails.getPlayerId(), request.getCurrentPassword(), request.getNewPassword());
             return ResponseEntity.ok("Password changed successfully");

--- a/src/main/java/com/sayai/record/auth/entity/Member.java
+++ b/src/main/java/com/sayai/record/auth/entity/Member.java
@@ -29,6 +29,10 @@ public class Member {
     @Setter
     private Role role;
 
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
     @PrePersist
     public void prePersist() {
         if (this.role == null) {

--- a/src/main/java/com/sayai/record/auth/service/AuthService.java
+++ b/src/main/java/com/sayai/record/auth/service/AuthService.java
@@ -51,4 +51,16 @@ public class AuthService {
 
         memberRepository.save(member);
     }
+
+    @Transactional
+    public void changePassword(Long playerId, String currentPassword, String newPassword) {
+        Member member = memberRepository.findById(playerId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        if (!passwordEncoder.matches(currentPassword, member.getPassword())) {
+            throw new IllegalArgumentException("Invalid current password");
+        }
+
+        member.changePassword(passwordEncoder.encode(newPassword));
+    }
 }

--- a/src/main/java/com/sayai/record/auth/service/AuthService.java
+++ b/src/main/java/com/sayai/record/auth/service/AuthService.java
@@ -54,6 +54,14 @@ public class AuthService {
 
     @Transactional
     public void changePassword(Long playerId, String currentPassword, String newPassword) {
+        if (currentPassword == null || currentPassword.isBlank() || newPassword == null || newPassword.isBlank()) {
+            throw new IllegalArgumentException("Password cannot be empty");
+        }
+
+        if (!newPassword.matches("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$")) {
+            throw new IllegalArgumentException("Password must be at least 8 characters long and contain both letters and numbers");
+        }
+
         Member member = memberRepository.findById(playerId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 

--- a/src/main/resources/templates/fragments/gnb.html
+++ b/src/main/resources/templates/fragments/gnb.html
@@ -58,6 +58,7 @@
 
         function closeMemberInfoModal() {
             $('#member-info-modal').css('display', 'none');
+        $('#member-info-modal input[type="password"]').val('');
         }
 
         function submitChangePassword() {

--- a/src/main/resources/templates/fragments/gnb.html
+++ b/src/main/resources/templates/fragments/gnb.html
@@ -6,6 +6,89 @@
     </div>
     <div class="gnb-right">
         <span id="gnb-user-name" style="margin-right: 15px; font-weight: bold; display: none;"></span>
+        <button id="gnb-member-info-btn" type="button" class="btn-primary" style="padding: 5px 10px; font-size: 0.9rem; margin-right: 10px; display: none; background-color: #6c757d; border-color: #6c757d;" onclick="openMemberInfoModal()">회원정보 변경</button>
         <button id="gnb-login-btn" type="button" class="btn-primary" style="padding: 5px 10px; font-size: 0.9rem;" onclick="openLoginModal()">로그인</button>
     </div>
+
+    <div id="member-info-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <span class="close-btn" onclick="closeMemberInfoModal()">&times;</span>
+            <h2 style="border-bottom: 2px solid #eee; padding-bottom: 10px; margin-bottom: 20px;">회원정보 변경</h2>
+
+            <div class="member-tab" style="margin-bottom: 20px;">
+                <div style="border-bottom: 2px solid #007bff; display: inline-block; padding: 5px 10px; font-weight: bold; color: #007bff;">비밀번호 변경</div>
+            </div>
+
+            <div class="form-group">
+                <label for="current-password">현재 비밀번호</label>
+                <input type="password" id="current-password" placeholder="현재 비밀번호 입력">
+            </div>
+            <div class="form-group">
+                <label for="new-password">새로운 비밀번호</label>
+                <input type="password" id="new-password" placeholder="새로운 비밀번호 입력">
+                <div style="color: #888; font-size: 0.8rem; margin-top: 5px;">영문, 숫자 포함 8자 이상</div>
+            </div>
+            <div class="form-group">
+                <label for="confirm-password">새로운 비밀번호 확인</label>
+                <input type="password" id="confirm-password" placeholder="새로운 비밀번호 확인">
+            </div>
+
+            <div style="text-align: right; margin-top: 20px;">
+                <button class="btn-primary" style="background-color: #6c757d; border-color: #6c757d; margin-right: 5px;" onclick="closeMemberInfoModal()">취소</button>
+                <button class="btn-primary" onclick="submitChangePassword()">변경</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        $(document).ready(function() {
+            if (localStorage.getItem('isLoggedIn')) {
+                $('#gnb-member-info-btn').show();
+            } else {
+                $('#gnb-member-info-btn').hide();
+            }
+        });
+
+        function openMemberInfoModal() {
+            $('#member-info-modal').css('display', 'flex');
+            $('#current-password').val('');
+            $('#new-password').val('');
+            $('#confirm-password').val('');
+        }
+
+        function closeMemberInfoModal() {
+            $('#member-info-modal').css('display', 'none');
+        }
+
+        function submitChangePassword() {
+            const currentPassword = $('#current-password').val();
+            const newPassword = $('#new-password').val();
+            const confirmPassword = $('#confirm-password').val();
+
+            if (newPassword !== confirmPassword) {
+                alert('새로운 비밀번호가 일치하지 않습니다.');
+                return;
+            }
+
+            const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+            if (!passwordRegex.test(newPassword)) {
+                alert('비밀번호는 영문과 숫자를 포함하여 8자 이상이어야 합니다.');
+                return;
+            }
+
+            $.ajax({
+                url: '/apis/v1/auth/password',
+                type: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ currentPassword: currentPassword, newPassword: newPassword }),
+                success: function(response) {
+                    alert('비밀번호가 변경되었습니다.');
+                    closeMemberInfoModal();
+                },
+                error: function(xhr) {
+                    alert('비밀번호 변경에 실패했습니다: ' + (xhr.responseText || '오류 발생'));
+                }
+            });
+        }
+    </script>
 </div>

--- a/src/test/java/com/sayai/record/auth/controller/AuthControllerPasswordTest.java
+++ b/src/test/java/com/sayai/record/auth/controller/AuthControllerPasswordTest.java
@@ -38,4 +38,15 @@ class AuthControllerPasswordTest {
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).isEqualTo("Password changed successfully");
     }
+
+    @Test
+    void changePassword_shouldReturnUnauthorized_whenUserDetailsIsNull() {
+        AuthController.ChangePasswordRequest request = new AuthController.ChangePasswordRequest();
+        request.setCurrentPassword("oldPass");
+        request.setNewPassword("newPass");
+
+        ResponseEntity<String> response = authController.changePassword(null, request);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(401);
+    }
 }

--- a/src/test/java/com/sayai/record/auth/controller/AuthControllerPasswordTest.java
+++ b/src/test/java/com/sayai/record/auth/controller/AuthControllerPasswordTest.java
@@ -1,0 +1,41 @@
+package com.sayai.record.auth.controller;
+
+import com.sayai.record.auth.jwt.CustomUserDetails;
+import com.sayai.record.auth.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerPasswordTest {
+
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private AuthController authController;
+
+    @Test
+    void changePassword_shouldCallServiceAndReturnOk() {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        when(userDetails.getPlayerId()).thenReturn(100L);
+
+        AuthController.ChangePasswordRequest request = new AuthController.ChangePasswordRequest();
+        request.setCurrentPassword("oldPass");
+        request.setNewPassword("newPass");
+
+        ResponseEntity<String> response = authController.changePassword(userDetails, request);
+
+        verify(authService).changePassword(100L, "oldPass", "newPass");
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isEqualTo("Password changed successfully");
+    }
+}

--- a/src/test/java/com/sayai/record/auth/service/AuthServicePasswordTest.java
+++ b/src/test/java/com/sayai/record/auth/service/AuthServicePasswordTest.java
@@ -1,0 +1,75 @@
+package com.sayai.record.auth.service;
+
+import com.sayai.record.auth.entity.Member;
+import com.sayai.record.auth.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServicePasswordTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void changePassword_shouldThrowException_whenPasswordIsEmpty() {
+        assertThatThrownBy(() -> authService.changePassword(1L, "", "newPass"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Password cannot be empty");
+
+        assertThatThrownBy(() -> authService.changePassword(1L, "oldPass", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Password cannot be empty");
+    }
+
+    @Test
+    void changePassword_shouldThrowException_whenNewPasswordIsInvalid() {
+        assertThatThrownBy(() -> authService.changePassword(1L, "oldPass", "short"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Password must be at least 8 characters long and contain both letters and numbers");
+
+        assertThatThrownBy(() -> authService.changePassword(1L, "oldPass", "onlyletters"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Password must be at least 8 characters long and contain both letters and numbers");
+
+        assertThatThrownBy(() -> authService.changePassword(1L, "oldPass", "12345678"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Password must be at least 8 characters long and contain both letters and numbers");
+    }
+
+    @Test
+    void changePassword_shouldSucceed_whenPasswordsAreValid() {
+        Member member = Member.builder()
+                .playerId(1L)
+                .password("encodedOldPass")
+                .role(Member.Role.USER)
+                .build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(passwordEncoder.matches("oldPass", "encodedOldPass")).thenReturn(true);
+        when(passwordEncoder.encode("newPass1")).thenReturn("encodedNewPass");
+
+        authService.changePassword(1L, "oldPass", "newPass1");
+
+        verify(passwordEncoder).encode("newPass1");
+        // Verify member was updated (mocking Member might be tricky as it's an entity,
+        // but verify interactions passed)
+    }
+}


### PR DESCRIPTION
Implemented a "Member Info" feature allowing logged-in users to change their password.
Added a modal to the GNB, accessible via a new button next to "Logout".
The modal includes validation for the new password (must be 8+ characters, alphanumeric).
Backend support includes a new endpoint in `AuthController`, service logic in `AuthService` to verify the current password before updating, and a method in the `Member` entity to update the password field.
Verified via Playwright script and Unit Test.

---
*PR created automatically by Jules for task [15654046806147316904](https://jules.google.com/task/15654046806147316904) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password change functionality enabling users to securely update their password through a dedicated member information modal. The new password must be at least 8 characters with both letters and digits. Users confirm their new password and verify their current password to proceed with the change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->