### PR TITLE
fix(fantasy): ensure draft timer and socket sync on mobile wake

### DIFF
--- a/src/main/resources/static/css/fantasy.css
+++ b/src/main/resources/static/css/fantasy.css
@@ -54,9 +54,56 @@
     gap: 20px;
 }
 
+/* Tab Styles (Mobile Only - Default Hidden on Desktop) */
+.draft-mobile-tabs {
+    display: none;
+    gap: 10px;
+    margin-bottom: 15px;
+    border-bottom: 2px solid #ddd;
+}
+
+.draft-tab {
+    padding: 10px 20px;
+    background: #f8f9fa;
+    border: 1px solid #ddd;
+    border-bottom: none;
+    border-radius: 5px 5px 0 0;
+    cursor: pointer;
+    font-weight: bold;
+    color: #555;
+    flex: 1; /* Equal width tabs */
+}
+
+.draft-tab.active {
+    background: #fff;
+    color: var(--kbo-blue);
+    border-color: #ddd #ddd #fff; /* Bottom border transparent to merge */
+    margin-bottom: -2px; /* Overlap border */
+}
+
+/* Mobile Media Query */
 @media (max-width: 768px) {
     .draft-container {
-        grid-template-columns: 1fr;
+        display: block; /* Stack (but we will hide one) */
+    }
+
+    .draft-mobile-tabs {
+        display: flex; /* Show tabs on mobile */
+    }
+
+    /* Hide inactive tabs content */
+    .draft-tab-content {
+        display: none;
+    }
+
+    .draft-tab-content.active {
+        display: block;
+    }
+
+    /* Hide Stats Column on Mobile (4th column: Name, Pos, Team, [Stats], Action) */
+    .fantasy-table th:nth-child(4),
+    .fantasy-table td:nth-child(4) {
+        display: none;
     }
 }
 

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -137,6 +137,7 @@
         const gameSeq = document.getElementById('gameSeq').value;
         const userId = document.getElementById('currentUserId').value;
         let stompClient = null;
+        let isConnecting = false;
 
         // Game State
         let gameState = {
@@ -261,15 +262,20 @@
 
 
         function connectWebSocket() {
-            if (stompClient && stompClient.connected) return;
+            if (isConnecting || (stompClient && stompClient.connected)) return;
 
+            isConnecting = true;
             const socket = new SockJS('/ws');
             stompClient = Stomp.over(socket);
             stompClient.connect({}, function(frame) {
+                isConnecting = false;
                 stompClient.subscribe('/topic/draft/' + gameSeq, function(message) {
                     const event = JSON.parse(message.body);
                     handleDraftEvent(event);
                 });
+            }, function(error) {
+                isConnecting = false;
+                console.error('STOMP connection error:', error);
             });
         }
 

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -64,9 +64,15 @@
         </div>
 
 
+        <!-- Mobile Tabs -->
+        <div class="draft-mobile-tabs">
+            <button class="draft-tab active" onclick="switchDraftTab('available')">선수 목록</button>
+            <button class="draft-tab" onclick="switchDraftTab('mypicks')">My Picks</button>
+        </div>
+
         <div class="draft-container">
             <!-- Available Players -->
-            <div class="fantasy-card">
+            <div id="tab-available" class="fantasy-card draft-tab-content active">
                 <h2 class="card-title">선수 목록</h2>
                 <div style="margin-bottom: 10px; display: flex; gap: 10px; flex-wrap: wrap;">
                     <select id="filter-team" style="padding: 5px;">
@@ -119,7 +125,7 @@
             </div>
 
             <!-- My Picks -->
-            <div class="fantasy-card">
+            <div id="tab-mypicks" class="fantasy-card draft-tab-content">
                 <h2 class="card-title">My Picks</h2>
                 <ul id="my-picks-list" style="list-style: none; padding: 0;">
                     <!-- Populated by JS -->
@@ -172,6 +178,17 @@
 
             setInterval(updateTimer, 1000);
         });
+
+        function switchDraftTab(tabName) {
+            // Only effective on mobile where tabs are shown
+            $('.draft-tab').removeClass('active');
+            $(`.draft-tab[onclick="switchDraftTab('${tabName}')"]`).addClass('active');
+
+            // Hide all tab contents and show the selected one
+            // Note: On desktop, CSS should override this to always show both
+            $('.draft-tab-content').removeClass('active');
+            $(`#tab-${tabName}`).addClass('active');
+        }
 
         function initGame() {
             $.get(`/apis/v1/fantasy/games/${gameSeq}/details`, function(data) {

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -153,6 +153,15 @@
             initGame();
             connectWebSocket();
 
+            // Mobile sync: Refresh state when returning to tab
+            document.addEventListener("visibilitychange", function() {
+                if (document.visibilityState === 'visible') {
+                    console.log("App resumed, syncing state...");
+                    initGame();
+                    connectWebSocket();
+                }
+            });
+
             $('#filter-team, #filter-position').change(function() {
                 loadAvailablePlayers();
             });
@@ -252,6 +261,8 @@
 
 
         function connectWebSocket() {
+            if (stompClient && stompClient.connected) return;
+
             const socket = new SockJS('/ws');
             stompClient = Stomp.over(socket);
             stompClient.connect({}, function(frame) {


### PR DESCRIPTION
Adds visibilitychange listener to draft.html to refresh game state and reconnect WebSocket when the browser tab becomes visible. This prevents timer drift and connection loss on mobile devices when backgrounded.

---
*PR created automatically by Jules for task [1667218467318697597](https://jules.google.com/task/1667218467318697597) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-friendly draft tabs and responsive layout for a cleaner small-screen drafting experience.
  * Tab-specific content containers so "My Picks" and "Available" show correctly on mobile.

* **Bug Fixes**
  * Automatic refresh and reconnection when returning to a browser tab to keep game state synchronized.
  * Prevents duplicate connection attempts and improves handling of connection errors for more stable reconnects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->