### PR TITLE
Fix timezone issue in Fantasy Game Details API

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/dto/DraftEventDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/DraftEventDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Getter
@@ -20,7 +21,7 @@ public class DraftEventDto {
 
     // Next Pick Info
     private Long nextPickerId;
-    private LocalDateTime nextPickDeadline;
+    private ZonedDateTime nextPickDeadline;
     private Integer round;
     private Integer pickInRound;
 

--- a/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/FantasyGameDetailDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Getter
@@ -25,7 +26,7 @@ public class FantasyGameDetailDto {
     private Integer participantCount;
     private Integer maxParticipants;
     private Long nextPickerId;
-    private LocalDateTime nextPickDeadline;
+    private ZonedDateTime nextPickDeadline;
     private Integer roundNum;
     private Integer pickInRound;
     private List<ParticipantRosterDto> participants;

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -186,7 +187,7 @@ public class FantasyDraftService {
                 .pickNumber(pickNumber)
                 .message(isFinished ? "Draft Completed!" : "Player " + request.getPlayerId() + " picked " + targetPlayer.getName() + " (Pick #" + pickNumber + ")")
                 .nextPickerId(isFinished ? null : nextNext.pickerId)
-                .nextPickDeadline(game.getNextPickDeadline())
+                .nextPickDeadline(game.getNextPickDeadline() != null ? game.getNextPickDeadline().atZone(ZoneId.of("UTC")) : null)
                 .round(isFinished ? null : nextNext.round)
                 .pickInRound(isFinished ? null : nextNext.pickInRound)
                 .build();

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -178,7 +179,7 @@ public class FantasyGameService {
                 .message("Draft Started")
                 .draftOrder(orderList)
                 .nextPickerId(orderList.get(0).getParticipantId()) // First picker
-                .nextPickDeadline(game.getNextPickDeadline())
+                .nextPickDeadline(game.getNextPickDeadline() != null ? game.getNextPickDeadline().atZone(ZoneId.of("UTC")) : null)
                 .round(1)
                 .pickInRound(1)
                 .build();
@@ -290,7 +291,7 @@ public class FantasyGameService {
                 .participantCount(participants.size())
                 .maxParticipants(game.getMaxParticipants())
                 .nextPickerId(nextPickerId)
-                .nextPickDeadline(game.getNextPickDeadline())
+                .nextPickDeadline(game.getNextPickDeadline() != null ? game.getNextPickDeadline().atZone(ZoneId.of("UTC")) : null)
                 .roundNum(round)
                 .pickInRound(pickInRound)
                 .participants(rosterDtos)

--- a/src/test/java/com/sayai/record/fantasy/api/FantasyGameDetailsTimezoneTest.java
+++ b/src/test/java/com/sayai/record/fantasy/api/FantasyGameDetailsTimezoneTest.java
@@ -1,0 +1,53 @@
+package com.sayai.record.fantasy.api;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.matchesPattern;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class FantasyGameDetailsTimezoneTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private FantasyGameRepository fantasyGameRepository;
+
+    @Test
+    @WithMockUser
+    public void getGameDetails_ShouldReturnZonedNextPickDeadline() throws Exception {
+        LocalDateTime deadline = LocalDateTime.of(2026, 2, 1, 8, 38, 51);
+
+        FantasyGame game = FantasyGame.builder()
+                .title("Timezone Test Game")
+                .status(FantasyGame.GameStatus.DRAFTING)
+                .ruleType(FantasyGame.RuleType.RULE_1)
+                .scoringType(FantasyGame.ScoringType.POINTS)
+                .maxParticipants(10)
+                .nextPickDeadline(deadline)
+                .build();
+
+        game = fantasyGameRepository.save(game);
+
+        mockMvc.perform(get("/apis/v1/fantasy/games/" + game.getSeq() + "/details"))
+                .andExpect(status().isOk())
+                // Expecting ISO 8601 with Z or +00:00.
+                // Since we used ZoneId.of("UTC"), it should likely be "Z" or "+00:00"
+                .andExpect(jsonPath("$.nextPickDeadline", matchesPattern(".*(Z|\\+00:00)$")));
+    }
+}


### PR DESCRIPTION
Changed `nextPickDeadline` in `FantasyGameDetailDto` and `DraftEventDto` from `LocalDateTime` to `ZonedDateTime`.
Updated `FantasyGameService` and `FantasyDraftService` to explicitly convert the stored `LocalDateTime` (UTC) to `ZonedDateTime` with UTC zone ID.
This ensures the API response includes timezone information (e.g., `Z`), allowing the frontend to correctly calculate the remaining time regardless of the client's local timezone.
Added `FantasyGameDetailsTimezoneTest` to verify the fix.

---
*PR created automatically by Jules for task [4129172549532807462](https://jules.google.com/task/4129172549532807462) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone handling for draft pick deadlines in fantasy games. Deadlines are now consistently stored and displayed with explicit UTC timezone information, preventing potential timezone-related confusion and ensuring accurate deadline representations across different regions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->