### PR TITLE
Refactor AdminController.listUsers to return MemberDto

### DIFF
--- a/src/main/java/com/sayai/record/admin/controller/AdminController.java
+++ b/src/main/java/com/sayai/record/admin/controller/AdminController.java
@@ -91,6 +91,12 @@ public class AdminController {
         return ResponseEntity.ok("Updated");
     }
 
+    @GetMapping("/fantasy/games/{gameSeq}/export-players")
+    public ResponseEntity<String> exportPlayers(@PathVariable(name = "gameSeq") Long gameSeq) {
+        String data = fantasyGameService.exportRoster(gameSeq);
+        return ResponseEntity.ok(data);
+    }
+
     // --- Scoring Endpoints ---
 
     @GetMapping("/fantasy/games/{gameSeq}/scores/{round}")

--- a/src/main/java/com/sayai/record/admin/controller/AdminController.java
+++ b/src/main/java/com/sayai/record/admin/controller/AdminController.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.BindingResult;
@@ -226,6 +227,7 @@ public class AdminController {
         private String userId;
 
         @NotBlank(message = "Password is required")
+        @ToString.Exclude
         private String password;
 
         @NotBlank(message = "Name is required")

--- a/src/main/java/com/sayai/record/admin/controller/AdminController.java
+++ b/src/main/java/com/sayai/record/admin/controller/AdminController.java
@@ -105,8 +105,12 @@ public class AdminController {
     // --- User Management ---
 
     @GetMapping("/users")
-    public ResponseEntity<List<Member>> listUsers() {
-        return ResponseEntity.ok(memberRepository.findAll());
+    public ResponseEntity<List<MemberDto>> listUsers() {
+        List<Member> members = memberRepository.findAll();
+        List<MemberDto> dtos = members.stream()
+                .map(MemberDto::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(dtos);
     }
 
     @PostMapping("/users")
@@ -215,5 +219,20 @@ public class AdminController {
         private String userId;
         private String password; // Optional, only if changing
         private String name;
+    }
+
+    @Data
+    public static class MemberDto {
+        private Long playerId;
+        private String userId;
+        private String name;
+        private Member.Role role;
+
+        public MemberDto(Member member) {
+            this.playerId = member.getPlayerId();
+            this.userId = member.getUserId();
+            this.name = member.getName();
+            this.role = member.getRole();
+        }
     }
 }

--- a/src/main/java/com/sayai/record/admin/controller/AdminController.java
+++ b/src/main/java/com/sayai/record/admin/controller/AdminController.java
@@ -9,10 +9,14 @@ import com.sayai.record.fantasy.entity.FantasyParticipant;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import com.sayai.record.fantasy.service.FantasyGameService;
 import com.sayai.record.fantasy.service.FantasyScoringService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -114,7 +118,14 @@ public class AdminController {
     }
 
     @PostMapping("/users")
-    public ResponseEntity<String> createUser(@RequestBody UserCreateRequest request) {
+    public ResponseEntity<String> createUser(@RequestBody @Valid UserCreateRequest request, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            String errorMessage = bindingResult.getAllErrors().stream()
+                    .map(error -> error.getDefaultMessage())
+                    .collect(Collectors.joining(", "));
+            return ResponseEntity.badRequest().body(errorMessage);
+        }
+
         if (memberRepository.existsById(request.getPlayerId())) {
             return ResponseEntity.badRequest().body("Player ID already exists");
         }
@@ -208,9 +219,16 @@ public class AdminController {
 
     @Data
     public static class UserCreateRequest {
+        @NotNull(message = "Player ID is required")
         private Long playerId;
+
+        @NotBlank(message = "User ID is required")
         private String userId;
+
+        @NotBlank(message = "Password is required")
         private String password;
+
+        @NotBlank(message = "Name is required")
         private String name;
     }
 

--- a/src/main/java/com/sayai/record/fantasy/dto/ParticipantStatsDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/ParticipantStatsDto.java
@@ -32,4 +32,7 @@ public class ParticipantStatsDto {
 
     // Total
     private Double totalPoints;
+
+    // Per Round Stats
+    private java.util.List<FantasyScoreDto> rounds;
 }

--- a/src/main/java/com/sayai/record/fantasy/dto/ParticipantStatsDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/ParticipantStatsDto.java
@@ -29,4 +29,7 @@ public class ParticipantStatsDto {
     private Double era;
     private Double whip;
     private Long saves;
+
+    // Total
+    private Double totalPoints;
 }

--- a/src/main/java/com/sayai/record/fantasy/entity/FantasyPlayer.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/FantasyPlayer.java
@@ -3,11 +3,10 @@ package com.sayai.record.fantasy.entity;
 import lombok.*;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Table(name = "ft_players")
 @Entity
 public class FantasyPlayer {
@@ -23,10 +22,31 @@ public class FantasyPlayer {
 
     private String stats;
 
+    @jakarta.validation.constraints.NotNull(message = "Cost cannot be null")
+    @Min(value = 0, message = "Cost must be non-negative")
+    @Column(columnDefinition = "integer check (cost >= 0)")
     private Integer cost;
 
     @Enumerated(EnumType.STRING)
     private ForeignerType foreignerType;
+
+    @Builder
+    public FantasyPlayer(Long seq, String name, String position, String team, String stats, Integer cost, ForeignerType foreignerType) {
+        this.seq = seq;
+        this.name = name;
+        this.position = position;
+        this.team = team;
+        this.stats = stats;
+        setCost(cost);
+        this.foreignerType = foreignerType;
+    }
+
+    public void setCost(Integer cost) {
+        if (cost == null || cost < 0) {
+            throw new IllegalArgumentException("Cost must be non-negative");
+        }
+        this.cost = cost;
+    }
 
     public enum ForeignerType {
         TYPE_1, // Foreigner

--- a/src/main/java/com/sayai/record/fantasy/entity/FantasyPlayer.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/FantasyPlayer.java
@@ -22,7 +22,7 @@ public class FantasyPlayer {
 
     private String stats;
 
-    @jakarta.validation.constraints.NotNull(message = "Cost cannot be null")
+    @jakarta.validation.constraints.NotNull(message = "Cost must be non-negative")
     @Min(value = 0, message = "Cost must be non-negative")
     @Column(columnDefinition = "integer check (cost >= 0)")
     private Integer cost;

--- a/src/main/java/com/sayai/record/fantasy/entity/FantasyRotisserieScore.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/FantasyRotisserieScore.java
@@ -9,7 +9,9 @@ import jakarta.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "ft_score_rotisserie")
+@Table(name = "ft_score_rotisserie", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"fantasy_game_seq", "player_id", "round"})
+})
 @Entity
 public class FantasyRotisserieScore {
 

--- a/src/main/java/com/sayai/record/fantasy/repository/FantasyRotisserieScoreRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/FantasyRotisserieScoreRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FantasyRotisserieScoreRepository extends JpaRepository<FantasyRotisserieScore, Long> {
+    List<FantasyRotisserieScore> findByFantasyGameSeq(Long fantasyGameSeq);
     List<FantasyRotisserieScore> findByFantasyGameSeqAndRound(Long fantasyGameSeq, Integer round);
     Optional<FantasyRotisserieScore> findByFantasyGameSeqAndPlayerIdAndRound(Long fantasyGameSeq, Long playerId, Integer round);
 }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -339,8 +339,8 @@ public class FantasyDraftService {
         FantasyGame game = fantasyGameRepository.findById(gameSeq)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid Game Seq"));
 
-        if (game.getStatus() == FantasyGame.GameStatus.DRAFTING || game.getStatus() == FantasyGame.GameStatus.FINISHED) {
-            throw new IllegalStateException("Cannot update roster during DRAFTING or when FINISHED.");
+        if (game.getStatus() == FantasyGame.GameStatus.FINISHED) {
+            throw new IllegalStateException("Cannot update roster when FINISHED.");
         }
 
         List<DraftPick> myPicks = draftPickRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId);

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -296,7 +296,12 @@ public class FantasyDraftService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        String[] positions = newPlayer.getPosition().split(",");
+        String positionStr = newPlayer.getPosition() != null ? newPlayer.getPosition() : "";
+        if (positionStr.trim().isEmpty()) {
+            return null; // Bench
+        }
+
+        String[] positions = positionStr.split(",");
         String primaryPos = positions[0].trim();
 
         if (isPitcher(primaryPos)) {
@@ -331,11 +336,39 @@ public class FantasyDraftService {
 
     @Transactional
     public void updateRoster(Long gameSeq, Long playerId, RosterUpdateDto updateDto) {
+        FantasyGame game = fantasyGameRepository.findById(gameSeq)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Game Seq"));
+
+        if (game.getStatus() == FantasyGame.GameStatus.DRAFTING || game.getStatus() == FantasyGame.GameStatus.FINISHED) {
+            throw new IllegalStateException("Cannot update roster during DRAFTING or when FINISHED.");
+        }
+
         List<DraftPick> myPicks = draftPickRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId);
         Map<Long, DraftPick> pickMap = myPicks.stream()
                 .collect(Collectors.toMap(DraftPick::getFantasyPlayerSeq, Function.identity()));
 
+        // Check validation first
         if (updateDto.getEntries() != null) {
+            Set<String> newPositions = new java.util.HashSet<>();
+            // Populate with existing positions NOT being updated
+            Set<Long> updatingSeqs = updateDto.getEntries().stream().map(RosterUpdateDto.RosterEntry::getFantasyPlayerSeq).collect(Collectors.toSet());
+            for (DraftPick pick : myPicks) {
+                if (!updatingSeqs.contains(pick.getFantasyPlayerSeq()) && pick.getAssignedPosition() != null) {
+                    if (!newPositions.add(pick.getAssignedPosition())) {
+                        // Data integrity error in DB? Or just conflict
+                    }
+                }
+            }
+
+            for (RosterUpdateDto.RosterEntry entry : updateDto.getEntries()) {
+                if (entry.getAssignedPosition() != null) {
+                    if (!newPositions.add(entry.getAssignedPosition())) {
+                        throw new IllegalArgumentException("Duplicate assigned position: " + entry.getAssignedPosition());
+                    }
+                }
+            }
+
+            // Apply updates
             for (RosterUpdateDto.RosterEntry entry : updateDto.getEntries()) {
                 DraftPick pick = pickMap.get(entry.getFantasyPlayerSeq());
                 if (pick != null) {
@@ -397,9 +430,22 @@ public class FantasyDraftService {
         // Optimize: we have allPlayers, can find from there
         List<FantasyPlayer> currentTeam = allPlayers.stream().filter(p -> userPickedSeqs.contains(p.getSeq())).collect(Collectors.toList());
 
+        int currentCost = 0;
+        if (game.getSalaryCap() != null && game.getSalaryCap() > 0) {
+            currentCost = currentTeam.stream().mapToInt(p -> p.getCost() == null ? 0 : p.getCost()).sum();
+        }
+
         FantasyPlayer selected = null;
         for (FantasyPlayer p : candidates) {
             try {
+                // Salary Cap Check
+                if (game.getSalaryCap() != null && game.getSalaryCap() > 0) {
+                    int newCost = p.getCost() == null ? 0 : p.getCost();
+                    if (currentCost + newCost > game.getSalaryCap()) {
+                        continue;
+                    }
+                }
+
                 draftValidator.validate(game, p, currentTeam, participant);
                 selected = p;
                 break;

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyRankingService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyRankingService.java
@@ -2,6 +2,7 @@ package com.sayai.record.fantasy.service;
 
 import com.sayai.record.dto.PitcherDto;
 import com.sayai.record.dto.PlayerDto;
+import com.sayai.record.fantasy.dto.FantasyScoreDto;
 import com.sayai.record.fantasy.dto.ParticipantStatsDto;
 import com.sayai.record.fantasy.dto.RankingTableDto;
 import com.sayai.record.fantasy.entity.DraftPick;
@@ -94,6 +95,8 @@ public class FantasyRankingService {
             double sumAvg = 0, sumEra = 0, sumWhip = 0;
             int countAvg = 0, countEra = 0, countWhip = 0;
 
+            List<FantasyScoreDto> roundDtos = new ArrayList<>();
+
             for (FantasyRotisserieScore s : myScores) {
                 totalPoints += safeDouble(s.getTotalPoints());
 
@@ -109,7 +112,13 @@ public class FantasyRankingService {
                 if (s.getAvg() != null) { sumAvg += s.getAvg(); countAvg++; }
                 if (s.getEra() != null) { sumEra += s.getEra(); countEra++; }
                 if (s.getWhip() != null) { sumWhip += s.getWhip(); countWhip++; }
+
+                roundDtos.add(convertToScoreDto(s));
             }
+
+            // Sort rounds
+            roundDtos.sort(Comparator.comparingInt(FantasyScoreDto::getRound));
+            dto.setRounds(roundDtos);
 
             dto.setTotalPoints(totalPoints);
             dto.setHomeruns(hr);
@@ -263,6 +272,26 @@ public class FantasyRankingService {
 
         response.setRankings(statsList);
         return response;
+    }
+
+    private FantasyScoreDto convertToScoreDto(FantasyRotisserieScore entity) {
+        return FantasyScoreDto.builder()
+                .seq(entity.getSeq())
+                .fantasyGameSeq(entity.getFantasyGameSeq())
+                .playerId(entity.getPlayerId())
+                .round(entity.getRound())
+                .avg(entity.getAvg())
+                .rbi(entity.getRbi())
+                .hr(entity.getHr())
+                .soBatter(entity.getSoBatter())
+                .sb(entity.getSb())
+                .wins(entity.getWins())
+                .era(entity.getEra())
+                .soPitcher(entity.getSoPitcher())
+                .whip(entity.getWhip())
+                .saves(entity.getSaves())
+                .totalPoints(entity.getTotalPoints())
+                .build();
     }
 
     private double safeDouble(Double val) {

--- a/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 @Component
 public class Rule1Validator implements DraftRuleValidator {
 
+    private static final int MAX_TYPE1_FOREIGNERS = 3;
+    private static final int MAX_TYPE2_FOREIGNERS = 1;
+
     private static final Map<String, Integer> BASE_SLOTS = new HashMap<>();
 
     static {
@@ -57,14 +60,21 @@ public class Rule1Validator implements DraftRuleValidator {
     }
 
     private void validateForeignerLimits(List<FantasyPlayer> team) {
-        long type1Count = team.stream().filter(p -> p.getForeignerType() == FantasyPlayer.ForeignerType.TYPE_1).count();
-        long type2Count = team.stream().filter(p -> p.getForeignerType() == FantasyPlayer.ForeignerType.TYPE_2).count();
+        long type1Count = team.stream().filter(p -> {
+            FantasyPlayer.ForeignerType type = Optional.ofNullable(p.getForeignerType()).orElse(FantasyPlayer.ForeignerType.NONE);
+            return type == FantasyPlayer.ForeignerType.TYPE_1;
+        }).count();
 
-        if (type1Count > 3) {
-            throw new IllegalStateException("Cannot draft more than 3 Foreigners (TYPE_1).");
+        long type2Count = team.stream().filter(p -> {
+            FantasyPlayer.ForeignerType type = Optional.ofNullable(p.getForeignerType()).orElse(FantasyPlayer.ForeignerType.NONE);
+            return type == FantasyPlayer.ForeignerType.TYPE_2;
+        }).count();
+
+        if (type1Count > MAX_TYPE1_FOREIGNERS) {
+            throw new IllegalStateException("Cannot draft more than " + MAX_TYPE1_FOREIGNERS + " Foreigners (TYPE_1).");
         }
-        if (type2Count > 1) {
-            throw new IllegalStateException("Cannot draft more than 1 Asian Quarter (TYPE_2).");
+        if (type2Count > MAX_TYPE2_FOREIGNERS) {
+            throw new IllegalStateException("Cannot draft more than " + MAX_TYPE2_FOREIGNERS + " Asian Quarter (TYPE_2).");
         }
     }
 

--- a/src/main/resources/schema-updates.sql
+++ b/src/main/resources/schema-updates.sql
@@ -1,2 +1,0 @@
-ALTER TABLE ft_score_rotisserie ADD CONSTRAINT uk_game_player_round UNIQUE (fantasy_game_seq, player_id, round);
-ALTER TABLE ft_players ADD CONSTRAINT chk_player_cost CHECK (cost >= 0);

--- a/src/main/resources/schema-updates.sql
+++ b/src/main/resources/schema-updates.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ft_score_rotisserie ADD CONSTRAINT uk_game_player_round UNIQUE (fantasy_game_seq, player_id, round);
+ALTER TABLE ft_players ADD CONSTRAINT chk_player_cost CHECK (cost >= 0);

--- a/src/main/resources/templates/fantasy/admin.html
+++ b/src/main/resources/templates/fantasy/admin.html
@@ -382,31 +382,6 @@
             });
         }
 
-        function openExportModal(gameSeq) {
-            $('#exportModal').css('display', 'flex');
-            $('#exportText').val("Loading...");
-            $.get(`/apis/v1/admin/fantasy/games/${gameSeq}/export-players`, function(data) {
-                $('#exportText').val(data);
-            }).fail(function() {
-                $('#exportText').val("Failed to load export data.");
-            });
-        }
-
-        function closeExportModal() {
-            $('#exportModal').hide();
-        }
-
-        function copyExportText() {
-            const copyText = document.getElementById("exportText");
-            copyText.select();
-            copyText.setSelectionRange(0, 99999); // Mobile
-            navigator.clipboard.writeText(copyText.value).then(function() {
-                alert("Copied to clipboard!");
-            }, function(err) {
-                alert("Failed to copy: " + err);
-            });
-        }
-
         function loadRoundScores(round) {
             currentScoringRound = round;
             $('#scoringMsg').text("Loading...");

--- a/src/main/resources/templates/fantasy/admin.html
+++ b/src/main/resources/templates/fantasy/admin.html
@@ -341,6 +341,31 @@
             $('#scoringModal').hide();
         }
 
+        function openExportModal(gameSeq) {
+            $('#exportModal').css('display', 'flex');
+            $('#exportText').val("Loading...");
+            $.get(`/apis/v1/admin/fantasy/games/${gameSeq}/export-players`, function(data) {
+                $('#exportText').val(data);
+            }).fail(function() {
+                $('#exportText').val("Failed to load export data.");
+            });
+        }
+
+        function closeExportModal() {
+            $('#exportModal').hide();
+        }
+
+        function copyExportText() {
+            const copyText = document.getElementById("exportText");
+            copyText.select();
+            copyText.setSelectionRange(0, 99999); // Mobile
+            navigator.clipboard.writeText(copyText.value).then(function() {
+                alert("Copied to clipboard!");
+            }, function(err) {
+                alert("Failed to copy: " + err);
+            });
+        }
+
         function loadRoundScores(round) {
             currentScoringRound = round;
             $('#scoringMsg').text("Loading...");
@@ -471,7 +496,8 @@
                                     </select>
                                     <button onclick="updateStatus(${game.seq})" class="btn-draft">Update</button>
                                     ${game.status === 'WAITING' ? `<button onclick="startDraft(${game.seq})" class="btn-primary" style="margin-left: 10px;">Start Draft</button>` : ''}
-                                    ${(game.status === 'ONGOING' || game.status === 'FINISHED') ? `<button onclick="openScoringModal(${game.seq})" class="btn-primary" style="margin-left: 10px; background-color: #6f42c1;">Scoring</button>` : ''}
+                                    ${(game.status === 'ONGOING' || game.status === 'FINISHED') ? `<button onclick="openScoringModal(${game.seq})" class="btn-primary" style="margin-left: 10px; background-color: #6f42c1;">Scoring</button>
+                                    <button onclick="openExportModal(${game.seq})" class="btn-primary" style="margin-left: 10px; background-color: #28a745;">Export</button>` : ''}
                                 </div>
                             </td>
                         </tr>

--- a/src/main/resources/templates/fantasy/admin.html
+++ b/src/main/resources/templates/fantasy/admin.html
@@ -235,6 +235,22 @@
         </div>
     </div>
 
+    <!-- Export Modal -->
+    <div id="exportModal" class="modal-overlay" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; justify-content: center; align-items: center;">
+        <div class="modal-container" style="background: white; padding: 20px; border-radius: 8px; width: 800px; max-width: 90%; max-height: 90vh; display: flex; flex-direction: column;">
+            <div class="modal-header" style="border-bottom: 1px solid #eee; margin-bottom: 15px; display: flex; justify-content: space-between; flex-shrink: 0;">
+                <h3 style="margin: 0;">Export Player List</h3>
+                <button onclick="closeExportModal()" style="background:none; border:none; font-size: 1.5rem; cursor: pointer;">&times;</button>
+            </div>
+            <div class="modal-body" style="overflow-y: auto; flex-grow: 1;">
+                <textarea id="exportText" style="width: 100%; height: 400px; padding: 10px;" readonly></textarea>
+            </div>
+            <div class="modal-footer" style="border-top: 1px solid #eee; padding-top: 15px; display: flex; justify-content: flex-end;">
+                <button onclick="copyExportText()" class="btn btn-primary">Copy to Clipboard</button>
+            </div>
+        </div>
+    </div>
+
     <script th:inline="javascript">
         /*<![CDATA[*/
         function openCreateModal() {
@@ -339,6 +355,31 @@
 
         function closeScoringModal() {
             $('#scoringModal').hide();
+        }
+
+        function openExportModal(gameSeq) {
+            $('#exportModal').css('display', 'flex');
+            $('#exportText').val("Loading...");
+            $.get(`/apis/v1/admin/fantasy/games/${gameSeq}/export-players`, function(data) {
+                $('#exportText').val(data);
+            }).fail(function() {
+                $('#exportText').val("Failed to load export data.");
+            });
+        }
+
+        function closeExportModal() {
+            $('#exportModal').hide();
+        }
+
+        function copyExportText() {
+            const copyText = document.getElementById("exportText");
+            copyText.select();
+            copyText.setSelectionRange(0, 99999); // Mobile
+            navigator.clipboard.writeText(copyText.value).then(function() {
+                alert("Copied to clipboard!");
+            }, function(err) {
+                alert("Failed to copy: " + err);
+            });
         }
 
         function openExportModal(gameSeq) {

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -161,7 +161,8 @@
             ruleType: 'RULE_1',
             myPreferredTeam: null,
             round: 1, // Default
-            salaryCap: null
+            salaryCap: null,
+            currentCost: 0
         };
 
         $(document).ready(function() {
@@ -379,7 +380,7 @@
 
                     // Salary Cap Check
                     if (isMyTurn && gameState.salaryCap && gameState.salaryCap > 0) {
-                        const currentCost = parseInt($('#current-cost').text()) || 0;
+                        const currentCost = gameState.currentCost || 0;
                         const playerCost = player.cost || 0;
                         if (currentCost + playerCost > gameState.salaryCap) {
                             disabled = true;
@@ -426,6 +427,7 @@
                     `);
                 });
                 $('#current-cost').text(totalCost);
+                gameState.currentCost = totalCost;
                 // Reload available players to update Over Cap buttons if cost changed
                 // Avoid infinite loop if calling from within init? init calls both.
                 // But loadAvailablePlayers doesn't call loadMyPicks.

--- a/src/main/resources/templates/fantasy/index.html
+++ b/src/main/resources/templates/fantasy/index.html
@@ -316,10 +316,10 @@
             roster.forEach(p => {
                 // Use assignedPosition if available
                 if (p.assignedPosition) {
-                    if (['SP', 'RP', 'CL'].includes(p.assignedPosition)) {
+                    if (['SP', 'RP', 'CL', 'CP'].includes(p.assignedPosition)) {
                          if (p.assignedPosition === 'SP') assignDetailPitcher('SP', spCount, p);
                          else if (p.assignedPosition === 'RP') assignDetailPitcher('RP', rpCount, p);
-                         else if (p.assignedPosition === 'CL') fillDetailPitcherSlot('CL-1', p);
+                         else if (p.assignedPosition === 'CL' || p.assignedPosition === 'CP') fillDetailPitcherSlot('CL-1', p);
                     } else {
                          fillDetailSlot(p.assignedPosition, p);
                     }

--- a/src/main/resources/templates/fantasy/my-team.html
+++ b/src/main/resources/templates/fantasy/my-team.html
@@ -98,10 +98,9 @@
                     <div class="pitcher-slot" id="slot-CL-1"><span class="pitcher-role">CP</span><span class="player-name">-</span></div>
                 </div>
             </div>
-        </div>
-
-        <div style="text-align: right; margin-bottom: 20px;">
-            <button id="saveRosterBtn" class="btn btn-primary">Save Roster</button>
+            <div style="text-align: right; margin-bottom: 20px;">
+                <button id="saveRosterBtn" class="btn btn-primary">Save Roster</button>
+            </div>
         </div>
 
         <div id="no-game-msg" style="display:none; text-align: center; padding: 50px;">
@@ -253,8 +252,8 @@
         }
 
         function loadMyGames() {
+            const select = $('#gameSelector');
             $.get('/apis/v1/fantasy/my-games', function(games) {
-                const select = $('#gameSelector');
                 select.empty();
 
                 if (games.length === 0) {

--- a/src/main/resources/templates/fantasy/my-team.html
+++ b/src/main/resources/templates/fantasy/my-team.html
@@ -294,6 +294,8 @@
                 let benchCount = 1;
 
                 players.forEach(p => {
+                    let placed = false;
+
                     // Try to use assignedPosition first
                     if (p.assignedPosition) {
                         const ap = p.assignedPosition;
@@ -301,49 +303,29 @@
                         if (ap.startsWith('BENCH')) {
                             // ap might be BENCH-1, BENCH-2 or just BENCH
                             // If BENCH-X, try exact match
-                            // If just BENCH, assign sequentially
                             if (ap.includes('-')) {
-                                let slot = $('#slot-' + ap);
-                                if(slot.length && !slot.data('player')) {
-                                     fillSlotById(slot.attr('id'), p);
-                                     return;
+                                if (fillSlotById('slot-' + ap, p)) {
+                                    placed = true;
                                 }
                             }
-                            // Fallback for BENCH or collision
-                            if (benchCount <= 3) {
-                                fillSlotById('slot-BENCH-' + benchCount, p);
-                                benchCount++;
+                            // If exact match failed or was generic 'BENCH', fall through to heuristic below
+                        } else if (ap === 'SP') {
+                            if (assignPitcher('SP', spCount, p)) placed = true;
+                        } else if (ap === 'RP') {
+                            if (assignPitcher('RP', rpCount, p)) placed = true;
+                        } else if (ap === 'CL' || ap === 'CP') {
+                            if (fillSlotById('slot-CL-1', p)) placed = true;
+                        } else {
+                            // Handle Specific Field (1B, C, etc)
+                            // Only if slot is free
+                            if (fillSlotById('slot-' + ap, p)) {
+                                placed = true;
                             }
-                            return;
-                        }
-
-                        // Handle Generic SP/RP
-                        if (ap === 'SP') {
-                            assignPitcher('SP', spCount, p);
-                            return;
-                        }
-                        if (ap === 'RP') {
-                            assignPitcher('RP', rpCount, p);
-                            return;
-                        }
-                        if (ap === 'CL' || ap === 'CP') {
-                            fillSlotById('slot-CL-1', p);
-                            return;
-                        }
-
-                        // Handle Specific Field (1B, C, etc)
-                        let slot = $('#slot-' + ap);
-                        if (slot.length && !slot.data('player')) {
-                            fillSlotById('slot-' + ap, p);
-                            return;
                         }
                     }
 
-                    // Fallback: Use Heuristic (e.g. initial load or no assignment)
-                    // (Same logic as before but with Bench fallback)
-                    // This is only if assignedPosition is null (should only happen for Bench in draft logic)
-                    // But our logic says null = Bench
-                    if (!p.assignedPosition) {
+                    // Fallback: If not placed yet (null assignedPosition, full slots, or collision)
+                    if (!placed) {
                          if (benchCount <= 3) {
                              fillSlotById('slot-BENCH-' + benchCount, p);
                              benchCount++;
@@ -355,10 +337,13 @@
 
         function fillSlotById(id, player) {
             const slot = $('#' + id);
-            if (slot.length) {
+            // Only fill if exists and empty
+            if (slot.length && !slot.data('player')) {
                 slot.data('player', player);
                 renderSlot(slot, player);
+                return true;
             }
+            return false;
         }
 
         function saveRoster(gameSeq) {
@@ -416,17 +401,23 @@
 
         function assignPitcher(type, counterObj, player) {
             if (counterObj.count <= 4) {
-                fillPitcherSlot(`${type}-${counterObj.count}`, player);
-                counterObj.count++;
+                // Try to fill next slot
+                if (fillPitcherSlot(`${type}-${counterObj.count}`, player)) {
+                    counterObj.count++;
+                    return true;
+                }
             }
+            return false;
         }
 
         function fillPitcherSlot(idSuffix, player) {
             const slot = $(`#slot-${idSuffix}`);
-            if (slot.length) {
+            if (slot.length && !slot.data('player')) {
                 slot.data('player', player);
                 renderSlot(slot, player);
+                return true;
             }
+            return false;
         }
         /*]]>*/
     </script>

--- a/src/main/resources/templates/fantasy/players.html
+++ b/src/main/resources/templates/fantasy/players.html
@@ -12,9 +12,6 @@
         <header class="fantasy-header" style="justify-content: space-between;">
             <div style="display:flex; align-items:center; gap: 20px;">
                 <h1>Player List</h1>
-                <select id="gameSelector" class="form-control" style="width: 200px; padding: 5px;">
-                    <option value="">Select Game...</option>
-                </select>
             </div>
             <button onclick="openPatchLog()" class="btn btn-primary" style="background-color: #6c757d;">Patch Log</button>
         </header>
@@ -121,14 +118,11 @@
         }
 
         function loadGames() {
-            const select = $('#gameSelector');
-            select.val(0);
             loadPlayers();
         }
 
         function loadPlayers() {
-            const gameSeq = $('#gameSelector').val();
-            if (!gameSeq) return;
+            const gameSeq = 0; // Always 0 to show all available players
 
             const team = $('#teamFilter').val();
             const pos = $('#posFilter').val();
@@ -186,10 +180,6 @@
 
         $(document).ready(function() {
             loadGames();
-
-            $('#gameSelector').change(function() {
-                loadPlayers();
-            });
 
             // Trigger search on enter in search input
             $('#searchInput').keypress(function(e) {

--- a/src/main/resources/templates/fantasy/players.html
+++ b/src/main/resources/templates/fantasy/players.html
@@ -150,22 +150,35 @@
                 }
 
                 players.forEach(p => {
-                    const row = `
-                        <tr>
-                            <td>
-                                <div>${p.name}</div>
-                                <div style="font-size:0.8rem; color:#888;">${p.team}</div>
-                            </td>
-                            <td>
-                                <span class="position-badge">${p.position}</span>
-                            </td>
-                            <td>${p.team}</td>
-                            <td>
-                                <span style="font-weight:bold; color:#007bff;">${p.cost || 0}</span>
-                            </td>
-                            <td style="font-size:0.9rem;">${p.stats || '-'}</td>
-                        </tr>
-                    `;
+                    const row = $('<tr>');
+
+                    // Name & Team (small)
+                    const nameCell = $('<td>');
+                    const nameDiv = $('<div>').text(p.name);
+                    const teamDiv = $('<div>').css({'font-size':'0.8rem', 'color':'#888'}).text(p.team);
+                    nameCell.append(nameDiv).append(teamDiv);
+                    row.append(nameCell);
+
+                    // Position
+                    const posCell = $('<td>');
+                    const posBadge = $('<span>').addClass('position-badge').text(p.position);
+                    posCell.append(posBadge);
+                    row.append(posCell);
+
+                    // Team
+                    const teamCell = $('<td>').text(p.team);
+                    row.append(teamCell);
+
+                    // Cost
+                    const costCell = $('<td>');
+                    const costSpan = $('<span>').css({'font-weight':'bold', 'color':'#007bff'}).text(p.cost || 0);
+                    costCell.append(costSpan);
+                    row.append(costCell);
+
+                    // Stats
+                    const statsCell = $('<td>').css('font-size', '0.9rem').text(p.stats || '-');
+                    row.append(statsCell);
+
                     tbody.append(row);
                 });
             });

--- a/src/main/resources/templates/fantasy/ranking.html
+++ b/src/main/resources/templates/fantasy/ranking.html
@@ -116,11 +116,16 @@
                 const tbody = $('#ranking-body');
                 tbody.empty();
 
-                data.rankings.forEach(r => {
+                data.rankings.forEach((r, index) => {
+                    let rankEmoji = '';
+                    if (index === 0) rankEmoji = '🥇 ';
+                    else if (index === 1) rankEmoji = '🥈 ';
+                    else if (index === 2) rankEmoji = '🥉 ';
+
                     const row = `
                         <tr>
                             <td style="font-weight:bold;">${r.teamName}</td>
-                            <td class="ranking-value" style="font-weight:bold; color: #007bff;">${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>
+                            <td class="ranking-value" style="font-weight:bold; color: #007bff;">${rankEmoji}${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>
                             <td class="ranking-value">${r.battingAvg ? r.battingAvg.toFixed(3) : '0.000'}</td>
                             <td class="ranking-value">${r.homeruns}</td>
                             <td class="ranking-value">${r.rbi}</td>

--- a/src/main/resources/templates/fantasy/ranking.html
+++ b/src/main/resources/templates/fantasy/ranking.html
@@ -36,6 +36,7 @@
                     <thead>
                         <tr>
                             <th class="ranking-header">Team Name</th>
+                            <th class="ranking-header">Total Points</th>
                             <th class="ranking-header">AVG</th>
                             <th class="ranking-header">HR</th>
                             <th class="ranking-header">RBI</th>
@@ -119,6 +120,7 @@
                     const row = `
                         <tr>
                             <td style="font-weight:bold;">${r.teamName}</td>
+                            <td class="ranking-value" style="font-weight:bold; color: #007bff;">${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>
                             <td class="ranking-value">${r.battingAvg ? r.battingAvg.toFixed(3) : '0.000'}</td>
                             <td class="ranking-value">${r.homeruns}</td>
                             <td class="ranking-value">${r.rbi}</td>

--- a/src/main/resources/templates/fantasy/ranking.html
+++ b/src/main/resources/templates/fantasy/ranking.html
@@ -36,7 +36,8 @@
                     <thead>
                         <tr>
                             <th class="ranking-header">Team Name</th>
-                            <th class="ranking-header">Total Points</th>
+                            <th class="ranking-header">Total Point</th>
+                            <th class="ranking-header">Point</th>
                             <th class="ranking-header">AVG</th>
                             <th class="ranking-header">HR</th>
                             <th class="ranking-header">RBI</th>
@@ -116,20 +117,45 @@
                 const tbody = $('#ranking-body');
                 tbody.empty();
 
-                // Calculate ranks for each category
-                const rankMaps = {
-                    totalPoints: calculateRanks(data.rankings, 'totalPoints', false),
-                    battingAvg: calculateRanks(data.rankings, 'battingAvg', false),
-                    homeruns: calculateRanks(data.rankings, 'homeruns', false),
-                    rbi: calculateRanks(data.rankings, 'rbi', false),
-                    batterStrikeOuts: calculateRanks(data.rankings, 'batterStrikeOuts', true), // Low is better
-                    stolenBases: calculateRanks(data.rankings, 'stolenBases', false),
-                    wins: calculateRanks(data.rankings, 'wins', false),
-                    pitcherStrikeOuts: calculateRanks(data.rankings, 'pitcherStrikeOuts', false),
-                    era: calculateRanks(data.rankings, 'era', true), // Low is better
-                    whip: calculateRanks(data.rankings, 'whip', true), // Low is better
-                    saves: calculateRanks(data.rankings, 'saves', false)
-                };
+                // Pre-process: Group per-round stats to calculate per-round ranks
+                // roundsData[roundNum] = [ { teamName, stats... }, ... ]
+                const roundsData = {};
+                data.rankings.forEach(r => {
+                    if (r.rounds) {
+                        r.rounds.forEach(roundStat => {
+                            if (!roundsData[roundStat.round]) {
+                                roundsData[roundStat.round] = [];
+                            }
+                            roundsData[roundStat.round].push({
+                                teamName: r.teamName,
+                                ...roundStat
+                            });
+                        });
+                    }
+                });
+
+                // Calculate ranks for each round
+                // roundRanks[roundNum] = { category: { teamName: rank } }
+                const roundRanks = {};
+                Object.keys(roundsData).forEach(roundNum => {
+                    const rData = roundsData[roundNum];
+                    roundRanks[roundNum] = {
+                        totalPoints: calculateRanks(rData, 'totalPoints', false),
+                        avg: calculateRanks(rData, 'avg', false),
+                        hr: calculateRanks(rData, 'hr', false),
+                        rbi: calculateRanks(rData, 'rbi', false),
+                        soBatter: calculateRanks(rData, 'soBatter', true), // Low is better
+                        sb: calculateRanks(rData, 'sb', false),
+                        wins: calculateRanks(rData, 'wins', false),
+                        soPitcher: calculateRanks(rData, 'soPitcher', false),
+                        era: calculateRanks(rData, 'era', true), // Low is better
+                        whip: calculateRanks(rData, 'whip', true), // Low is better
+                        saves: calculateRanks(rData, 'saves', false)
+                    };
+                });
+
+                // Also calculate Total Point Rank for the main column
+                const totalRankMap = calculateRanks(data.rankings, 'totalPoints', false);
 
                 function getEmoji(rank) {
                     if (rank === 1) return '🥇 ';
@@ -139,24 +165,89 @@
                 }
 
                 data.rankings.forEach(r => {
-                    const row = `
-                        <tr>
-                            <td style="font-weight:bold;">${r.teamName}</td>
-                            <td class="ranking-value" style="font-weight:bold; color: #007bff;">${getEmoji(rankMaps.totalPoints[r.teamName])}${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.battingAvg[r.teamName])}${r.battingAvg ? r.battingAvg.toFixed(3) : '0.000'}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.homeruns[r.teamName])}${r.homeruns}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.rbi[r.teamName])}${r.rbi}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.batterStrikeOuts[r.teamName])}${r.batterStrikeOuts}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.stolenBases[r.teamName])}${r.stolenBases}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.wins[r.teamName])}${r.wins}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.pitcherStrikeOuts[r.teamName])}${r.pitcherStrikeOuts}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.era[r.teamName])}${r.era ? r.era.toFixed(2) : '0.00'}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.whip[r.teamName])}${r.whip ? r.whip.toFixed(2) : '0.00'}</td>
-                            <td class="ranking-value">${getEmoji(rankMaps.saves[r.teamName])}${r.saves}</td>
-                        </tr>
-                    `;
-                    tbody.append(row);
+                    const rowCount = (r.rounds && r.rounds.length > 0) ? r.rounds.length : 1;
+                    const totalEmoji = getEmoji(totalRankMap[r.teamName]);
+
+                    // First Row (Main + First Round)
+                    let html = '<tr>';
+
+                    // Merged Cells
+                    html += `<td rowspan="${rowCount}" style="font-weight:bold; vertical-align:middle; background:#fff;">${r.teamName}</td>`;
+                    html += `<td rowspan="${rowCount}" class="ranking-value" style="font-weight:bold; color:#007bff; vertical-align:middle; background:#fff; font-size:1.1rem;">${totalEmoji}${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>`;
+
+                    // First Round Data
+                    if (r.rounds && r.rounds.length > 0) {
+                        const first = r.rounds[0];
+                        const rk = roundRanks[first.round];
+                        html += renderRoundCells(first, rk, r.teamName);
+                    } else {
+                        // Empty cells if no round data
+                        html += '<td colspan="11" class="ranking-value">-</td>';
+                    }
+                    html += '</tr>';
+                    tbody.append(html);
+
+                    // Subsequent Rows
+                    if (r.rounds && r.rounds.length > 1) {
+                        for(let i=1; i<r.rounds.length; i++) {
+                            const sub = r.rounds[i];
+                            const subRk = roundRanks[sub.round];
+                            let subHtml = '<tr>';
+                            subHtml += renderRoundCells(sub, subRk, r.teamName);
+                            subHtml += '</tr>';
+                            tbody.append(subHtml);
+                        }
+                    }
                 });
+
+                function renderRoundCells(stats, rankMap, teamName) {
+                    // rankMap is for a specific round: { category: { teamName: rank } }
+                    // We need to pass teamName to look up rank
+
+                    const p = (key) => {
+                        const rank = rankMap[key][teamName];
+                        const val = stats[key];
+                        const fixed = (key === 'avg') ? 3 : (key === 'era' || key === 'whip' || key === 'totalPoints') ? 2 : 0; // Point usually integer? But totalPoints in DTO is double.
+                        // Wait, 'Point' column in image is round point. In DTO it's 'totalPoints' field of FantasyScoreDto.
+                        // And image shows 120, 110 (integers?). Let's use 1 decimal for points.
+                        if (val === null || val === undefined) return '';
+
+                        let displayVal = val;
+                        if (key === 'avg') displayVal = val.toFixed(3);
+                        else if (key === 'era' || key === 'whip') displayVal = val.toFixed(2);
+                        else if (key === 'totalPoints') displayVal = val.toFixed(1); // Round Point
+
+                        return `<td class="ranking-value">${getEmoji(rank)}${displayVal}</td>`;
+                    };
+
+                    // Mappings:
+                    // DTO field -> Table Column
+                    // Point -> totalPoints
+                    // AVG -> avg
+                    // HR -> hr
+                    // RBI -> rbi
+                    // SO(Bat) -> soBatter
+                    // SB -> sb
+                    // W -> wins
+                    // K(Pitch) -> soPitcher
+                    // ERA -> era
+                    // WHIP -> whip
+                    // SV -> saves
+
+                    let s = '';
+                    s += p('totalPoints');
+                    s += p('avg');
+                    s += p('hr');
+                    s += p('rbi');
+                    s += p('soBatter');
+                    s += p('sb');
+                    s += p('wins');
+                    s += p('soPitcher');
+                    s += p('era');
+                    s += p('whip');
+                    s += p('saves');
+                    return s;
+                }
             });
         }
 

--- a/src/main/resources/templates/fantasy/ranking.html
+++ b/src/main/resources/templates/fantasy/ranking.html
@@ -34,24 +34,24 @@
             <div style="overflow-x: auto;">
                 <table class="table table-hover fantasy-table">
                     <thead>
-                        <tr>
-                            <th class="ranking-header">Team Name</th>
-                            <th class="ranking-header">Total Point</th>
-                            <th class="ranking-header">Point</th>
-                            <th class="ranking-header">AVG</th>
-                            <th class="ranking-header">HR</th>
-                            <th class="ranking-header">RBI</th>
-                            <th class="ranking-header">SO (Bat)</th>
-                            <th class="ranking-header">SB</th>
-                            <th class="ranking-header">W</th>
-                            <th class="ranking-header">K (Pitch)</th>
-                            <th class="ranking-header">ERA</th>
-                            <th class="ranking-header">WHIP</th>
-                            <th class="ranking-header">SV</th>
-                        </tr>
+                    <tr>
+                        <th class="ranking-header">Team Name</th>
+                        <th class="ranking-header">Total Point</th>
+                        <th class="ranking-header">Point</th>
+                        <th class="ranking-header">AVG</th>
+                        <th class="ranking-header">HR</th>
+                        <th class="ranking-header">RBI</th>
+                        <th class="ranking-header">SO (Bat)</th>
+                        <th class="ranking-header">SB</th>
+                        <th class="ranking-header">W</th>
+                        <th class="ranking-header">K (Pitch)</th>
+                        <th class="ranking-header">ERA</th>
+                        <th class="ranking-header">WHIP</th>
+                        <th class="ranking-header">SV</th>
+                    </tr>
                     </thead>
                     <tbody id="ranking-body">
-                        <!-- Filled by JS -->
+                    <!-- Filled by JS -->
                     </tbody>
                 </table>
             </div>
@@ -198,7 +198,9 @@
                             tbody.append(subHtml);
                         }
                     }
+
                 });
+                $('#ranking-view').show();
 
                 function renderRoundCells(stats, rankMap, teamName) {
                     // rankMap is for a specific round: { category: { teamName: rank } }
@@ -274,9 +276,6 @@
             return ranks;
         }
 
-                $('#ranking-view').show();
-            });
-        }
         /*]]>*/
     </script>
 </div>

--- a/src/main/resources/templates/fantasy/ranking.html
+++ b/src/main/resources/templates/fantasy/ranking.html
@@ -116,30 +116,72 @@
                 const tbody = $('#ranking-body');
                 tbody.empty();
 
-                data.rankings.forEach((r, index) => {
-                    let rankEmoji = '';
-                    if (index === 0) rankEmoji = '🥇 ';
-                    else if (index === 1) rankEmoji = '🥈 ';
-                    else if (index === 2) rankEmoji = '🥉 ';
+                // Calculate ranks for each category
+                const rankMaps = {
+                    totalPoints: calculateRanks(data.rankings, 'totalPoints', false),
+                    battingAvg: calculateRanks(data.rankings, 'battingAvg', false),
+                    homeruns: calculateRanks(data.rankings, 'homeruns', false),
+                    rbi: calculateRanks(data.rankings, 'rbi', false),
+                    batterStrikeOuts: calculateRanks(data.rankings, 'batterStrikeOuts', true), // Low is better
+                    stolenBases: calculateRanks(data.rankings, 'stolenBases', false),
+                    wins: calculateRanks(data.rankings, 'wins', false),
+                    pitcherStrikeOuts: calculateRanks(data.rankings, 'pitcherStrikeOuts', false),
+                    era: calculateRanks(data.rankings, 'era', true), // Low is better
+                    whip: calculateRanks(data.rankings, 'whip', true), // Low is better
+                    saves: calculateRanks(data.rankings, 'saves', false)
+                };
 
+                function getEmoji(rank) {
+                    if (rank === 1) return '🥇 ';
+                    if (rank === 2) return '🥈 ';
+                    if (rank === 3) return '🥉 ';
+                    return '';
+                }
+
+                data.rankings.forEach(r => {
                     const row = `
                         <tr>
                             <td style="font-weight:bold;">${r.teamName}</td>
-                            <td class="ranking-value" style="font-weight:bold; color: #007bff;">${rankEmoji}${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>
-                            <td class="ranking-value">${r.battingAvg ? r.battingAvg.toFixed(3) : '0.000'}</td>
-                            <td class="ranking-value">${r.homeruns}</td>
-                            <td class="ranking-value">${r.rbi}</td>
-                            <td class="ranking-value">${r.batterStrikeOuts}</td>
-                            <td class="ranking-value">${r.stolenBases}</td>
-                            <td class="ranking-value">${r.wins}</td>
-                            <td class="ranking-value">${r.pitcherStrikeOuts}</td>
-                            <td class="ranking-value">${r.era ? r.era.toFixed(2) : '0.00'}</td>
-                            <td class="ranking-value">${r.whip ? r.whip.toFixed(2) : '0.00'}</td>
-                            <td class="ranking-value">${r.saves}</td>
+                            <td class="ranking-value" style="font-weight:bold; color: #007bff;">${getEmoji(rankMaps.totalPoints[r.teamName])}${r.totalPoints ? r.totalPoints.toFixed(1) : '0.0'}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.battingAvg[r.teamName])}${r.battingAvg ? r.battingAvg.toFixed(3) : '0.000'}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.homeruns[r.teamName])}${r.homeruns}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.rbi[r.teamName])}${r.rbi}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.batterStrikeOuts[r.teamName])}${r.batterStrikeOuts}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.stolenBases[r.teamName])}${r.stolenBases}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.wins[r.teamName])}${r.wins}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.pitcherStrikeOuts[r.teamName])}${r.pitcherStrikeOuts}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.era[r.teamName])}${r.era ? r.era.toFixed(2) : '0.00'}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.whip[r.teamName])}${r.whip ? r.whip.toFixed(2) : '0.00'}</td>
+                            <td class="ranking-value">${getEmoji(rankMaps.saves[r.teamName])}${r.saves}</td>
                         </tr>
                     `;
                     tbody.append(row);
                 });
+            });
+        }
+
+        function calculateRanks(data, key, ascending) {
+            const sorted = [...data].sort((a, b) => {
+                const valA = a[key] || 0;
+                const valB = b[key] || 0;
+                if (ascending) return valA - valB;
+                return valB - valA;
+            });
+
+            const ranks = {};
+            let currentRank = 1;
+            for (let i = 0; i < sorted.length; i++) {
+                if (i > 0) {
+                    const prev = sorted[i - 1][key] || 0;
+                    const curr = sorted[i][key] || 0;
+                    if (Math.abs(prev - curr) > 0.00001) { // Simple float comparison
+                        currentRank = i + 1;
+                    }
+                }
+                ranks[sorted[i].teamName] = currentRank;
+            }
+            return ranks;
+        }
 
                 $('#ranking-view').show();
             });

--- a/src/test/java/com/sayai/record/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/sayai/record/admin/controller/AdminControllerTest.java
@@ -1,9 +1,12 @@
 package com.sayai.record.admin.controller;
 
+import com.sayai.record.auth.entity.Member;
 import com.sayai.record.auth.repository.MemberRepository;
 import com.sayai.record.fantasy.entity.FantasyGame;
 import com.sayai.record.fantasy.service.FantasyGameService;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -44,5 +47,27 @@ class AdminControllerTest {
 
         assertThat(response.getBody().getTitle()).isEqualTo("New League");
         assertThat(response.getBody().getScoringType()).isEqualTo(FantasyGame.ScoringType.POINTS);
+    }
+
+    @Test
+    void listUsers_shouldReturnMemberDtos() {
+        Member member = Member.builder()
+                .playerId(1L)
+                .userId("testuser")
+                .name("Test User")
+                .role(Member.Role.USER)
+                .password("encodedPwd")
+                .build();
+
+        when(memberRepository.findAll()).thenReturn(List.of(member));
+
+        ResponseEntity<List<AdminController.MemberDto>> response = adminController.listUsers();
+
+        assertThat(response.getBody()).hasSize(1);
+        AdminController.MemberDto dto = response.getBody().get(0);
+        assertThat(dto.getPlayerId()).isEqualTo(1L);
+        assertThat(dto.getUserId()).isEqualTo("testuser");
+        assertThat(dto.getName()).isEqualTo("Test User");
+        assertThat(dto.getRole()).isEqualTo(Member.Role.USER);
     }
 }

--- a/src/test/java/com/sayai/record/fantasy/entity/FantasyPlayerTest.java
+++ b/src/test/java/com/sayai/record/fantasy/entity/FantasyPlayerTest.java
@@ -1,0 +1,43 @@
+package com.sayai.record.fantasy.entity;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FantasyPlayerTest {
+
+    @Test
+    void builder_shouldThrowException_whenCostIsNegative() {
+        assertThatThrownBy(() -> FantasyPlayer.builder()
+                .cost(-100)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cost must be non-negative");
+    }
+
+    @Test
+    void setCost_shouldThrowException_whenCostIsNegative() {
+        FantasyPlayer player = new FantasyPlayer();
+        assertThatThrownBy(() -> player.setCost(-50))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cost must be non-negative");
+    }
+
+    @Test
+    void setCost_shouldThrowException_whenCostIsNull() {
+        FantasyPlayer player = new FantasyPlayer();
+        assertThatThrownBy(() -> player.setCost(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cost must be non-negative");
+    }
+
+    @Test
+    void setCost_shouldSucceed_whenCostIsZeroOrPositive() {
+        FantasyPlayer player = new FantasyPlayer();
+        player.setCost(0);
+        assertThat(player.getCost()).isEqualTo(0);
+
+        player.setCost(100);
+        assertThat(player.getCost()).isEqualTo(100);
+    }
+}

--- a/src/test/java/com/sayai/record/fantasy/service/DraftValidatorTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/DraftValidatorTest.java
@@ -27,7 +27,7 @@ class DraftValidatorTest {
     @Test
     void validate_shouldDelegateToRule1() {
         FantasyGame game = FantasyGame.builder().ruleType(FantasyGame.RuleType.RULE_1).build();
-        FantasyPlayer p1 = FantasyPlayer.builder().position("1B").build();
+        FantasyPlayer p1 = FantasyPlayer.builder().position("1B").cost(10).build();
 
         assertThatCode(() -> draftValidator.validate(game, p1, Collections.emptyList(), null))
                 .doesNotThrowAnyException();
@@ -37,7 +37,7 @@ class DraftValidatorTest {
     void validate_shouldDelegateToRule2() {
         FantasyGame game = FantasyGame.builder().ruleType(FantasyGame.RuleType.RULE_2).build();
         FantasyParticipant participant = FantasyParticipant.builder().preferredTeam("TeamA").build();
-        FantasyPlayer p1 = FantasyPlayer.builder().team("TeamB").position("C").build(); // Wrong Team
+        FantasyPlayer p1 = FantasyPlayer.builder().team("TeamB").position("C").cost(10).build(); // Wrong Team
 
         assertThatThrownBy(() -> draftValidator.validate(game, p1, Collections.emptyList(), participant))
                 .isInstanceOf(IllegalStateException.class)

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceFilterTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceFilterTest.java
@@ -34,7 +34,7 @@ class FantasyDraftServiceFilterTest {
         String pos = "P";
         String search = "Kim";
 
-        FantasyPlayer p1 = FantasyPlayer.builder().seq(1L).name("Kim").team("Doosan").position("P").build();
+        FantasyPlayer p1 = FantasyPlayer.builder().seq(1L).name("Kim").team("Doosan").position("P").cost(10).build();
 
         when(draftPickRepository.findByFantasyGameSeq(gameSeq)).thenReturn(Collections.emptyList());
         when(fantasyPlayerRepository.findPlayers(team, pos, search)).thenReturn(Collections.singletonList(p1));

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceRosterTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceRosterTest.java
@@ -1,0 +1,82 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.dto.RosterUpdateDto;
+import com.sayai.record.fantasy.entity.DraftPick;
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.repository.DraftPickRepository;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FantasyDraftServiceRosterTest {
+
+    @Mock
+    private FantasyGameRepository fantasyGameRepository;
+    @Mock
+    private DraftPickRepository draftPickRepository;
+
+    @InjectMocks
+    private FantasyDraftService fantasyDraftService;
+
+    @Test
+    void updateRoster_shouldAllowMultiplePitchers() {
+        Long gameSeq = 1L;
+        Long playerId = 100L;
+        FantasyGame game = FantasyGame.builder().status(FantasyGame.GameStatus.ONGOING).build();
+
+        // Existing picks: SP, SP (total 2 SPs)
+        DraftPick pick1 = DraftPick.builder().fantasyPlayerSeq(1L).playerId(playerId).assignedPosition("SP").build();
+        DraftPick pick2 = DraftPick.builder().fantasyPlayerSeq(2L).playerId(playerId).assignedPosition("SP").build();
+        // New assignment: another SP (total 3 SPs -> allowed, limit 4)
+        DraftPick pick3 = DraftPick.builder().fantasyPlayerSeq(3L).playerId(playerId).assignedPosition(null).build(); // Unassigned initially
+
+        when(fantasyGameRepository.findById(gameSeq)).thenReturn(Optional.of(game));
+        when(draftPickRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId))
+                .thenReturn(List.of(pick1, pick2, pick3));
+
+        RosterUpdateDto dto = new RosterUpdateDto();
+        dto.setEntries(List.of(new RosterUpdateDto.RosterEntry(3L, "SP")));
+
+        assertThatCode(() -> fantasyDraftService.updateRoster(gameSeq, playerId, dto))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void updateRoster_shouldThrow_whenLimitExceeded() {
+        Long gameSeq = 1L;
+        Long playerId = 100L;
+        FantasyGame game = FantasyGame.builder().status(FantasyGame.GameStatus.ONGOING).build();
+
+        // Existing picks: 4 SPs already
+        DraftPick pick1 = DraftPick.builder().fantasyPlayerSeq(1L).playerId(playerId).assignedPosition("SP").build();
+        DraftPick pick2 = DraftPick.builder().fantasyPlayerSeq(2L).playerId(playerId).assignedPosition("SP").build();
+        DraftPick pick3 = DraftPick.builder().fantasyPlayerSeq(3L).playerId(playerId).assignedPosition("SP").build();
+        DraftPick pick4 = DraftPick.builder().fantasyPlayerSeq(4L).playerId(playerId).assignedPosition("SP").build();
+
+        // Attempt to set 5th SP
+        DraftPick pick5 = DraftPick.builder().fantasyPlayerSeq(5L).playerId(playerId).assignedPosition(null).build();
+
+        when(fantasyGameRepository.findById(gameSeq)).thenReturn(Optional.of(game));
+        when(draftPickRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId))
+                .thenReturn(List.of(pick1, pick2, pick3, pick4, pick5));
+
+        RosterUpdateDto dto = new RosterUpdateDto();
+        dto.setEntries(List.of(new RosterUpdateDto.RosterEntry(5L, "SP")));
+
+        assertThatThrownBy(() -> fantasyDraftService.updateRoster(gameSeq, playerId, dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Position limit exceeded");
+    }
+}

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceRosterTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceRosterTest.java
@@ -34,7 +34,7 @@ class FantasyDraftServiceRosterTest {
     void updateRoster_shouldAllowMultiplePitchers() {
         Long gameSeq = 1L;
         Long playerId = 100L;
-        FantasyGame game = FantasyGame.builder().status(FantasyGame.GameStatus.ONGOING).build();
+        FantasyGame game = FantasyGame.builder().status(FantasyGame.GameStatus.DRAFTING).build(); // Allowed now
 
         // Existing picks: SP, SP (total 2 SPs)
         DraftPick pick1 = DraftPick.builder().fantasyPlayerSeq(1L).playerId(playerId).assignedPosition("SP").build();

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceTest.java
@@ -74,6 +74,7 @@ class FantasyGameServiceTest {
                 .name("Player 1")
                 .position("1B")
                 .team("KIA")
+                .cost(10)
                 .build();
         when(fantasyPlayerRepository.findAllById(any())).thenReturn(List.of(fantasyPlayer));
 

--- a/src/test/java/com/sayai/record/fantasy/service/rules/Rule1ValidatorTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/rules/Rule1ValidatorTest.java
@@ -1,0 +1,62 @@
+package com.sayai.record.fantasy.service.rules;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.entity.FantasyParticipant;
+import com.sayai.record.fantasy.entity.FantasyPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Rule1ValidatorTest {
+
+    private Rule1Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new Rule1Validator();
+    }
+
+    @Test
+    void validate_shouldPass_whenNullForeignerTypeIsCountedAsNone() {
+        FantasyGame game = FantasyGame.builder().build();
+        FantasyParticipant participant = FantasyParticipant.builder().build();
+        List<FantasyPlayer> currentTeam = new ArrayList<>();
+
+        // Add 3 TYPE_1 foreigners (Max allowed)
+        for (int i = 0; i < 3; i++) {
+            currentTeam.add(FantasyPlayer.builder().position("1B").foreignerType(FantasyPlayer.ForeignerType.TYPE_1).cost(10).build());
+        }
+
+        // Try to add a player with NULL foreigner type -> Should count as NONE and PASS
+        // We use a position that fits (e.g. DH if we have slots, but Rule1Validator checks composition too)
+        // To simplify composition check failure, we mock valid composition or use simple slots.
+        // But since we want to test foreigner limit logic specifically, we can just ensure composition passes or focus on that logic.
+        // Actually Rule1Validator.validate calls canFit() first. We need to respect positions.
+        // Let's create a minimal team that fits composition but pushes foreigner limit.
+
+        // Actually simpler: Testing validateForeignerLimits is private, so we test via validate.
+        // We need to construct a team that satisfies `canFit` to reach `validateForeignerLimits`.
+        // This might be complex due to backtracking.
+
+        // Alternative: Use reflection to test private method or trust that if I provide valid positions it works.
+        // Let's try to provide valid positions.
+        // 3 TYPE_1: 1B, 2B, 3B
+        // New Player: Null Type (NONE), Position SS.
+        // Total 4 players. All fit into C, 1B, 2B, SS, 3B etc.
+
+        List<FantasyPlayer> team = new ArrayList<>();
+        team.add(FantasyPlayer.builder().position("1B").foreignerType(FantasyPlayer.ForeignerType.TYPE_1).cost(10).build());
+        team.add(FantasyPlayer.builder().position("2B").foreignerType(FantasyPlayer.ForeignerType.TYPE_1).cost(10).build());
+        team.add(FantasyPlayer.builder().position("3B").foreignerType(FantasyPlayer.ForeignerType.TYPE_1).cost(10).build());
+
+        FantasyPlayer newPlayer = FantasyPlayer.builder().position("SS").foreignerType(null).cost(10).build();
+
+        assertThatCode(() -> validator.validate(game, newPlayer, team, participant))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Refactor AdminController.listUsers to return MemberDto instead of Member entity to prevent exposing sensitive fields like password. Added MemberDto static inner class and updated listUsers method. Added test case listUsers_shouldReturnMemberDtos in AdminControllerTest.

---
*PR created automatically by Jules for task [8770153120297186660](https://jules.google.com/task/8770153120297186660) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roster export endpoint plus Admin "Export" modal for copying/downloading team rosters.
  * Rotisserie scoring and ranking UI with per-round details and Total Points.

* **Updates**
  * User creation now validates inputs with clear 400 messages; user list returns simplified DTOs.
  * Drafting enforcement: roster position limits, salary-cap checks, and CP handled with pitchers.
  * Player import more robust; UI tracks current team cost.

* **Data Integrity**
  * Added unique and check constraints for scores and player cost.

* **Tests**
  * Expanded coverage for validation, cost rules, draft/roster rules, and rotisserie ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->