### PR TITLE
Fix available-players API returning empty list when gameSeq is 0 due to empty filters

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/entity/FantasyPlayer.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/FantasyPlayer.java
@@ -1,5 +1,6 @@
 package com.sayai.record.fantasy.entity;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import jakarta.persistence.*;
@@ -22,7 +23,7 @@ public class FantasyPlayer {
 
     private String stats;
 
-    @jakarta.validation.constraints.NotNull(message = "Cost must be non-negative")
+    @NotNull(message = "Cost must be non-negative")
     @Min(value = 0, message = "Cost must be non-negative")
     @Column(columnDefinition = "integer check (cost >= 0)")
     private Integer cost;

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -71,11 +71,20 @@ public class FantasyDraftService {
 
     @Transactional(readOnly = true)
     public List<FantasyPlayerDto> getAvailablePlayers(Long gameSeq, String team, String position, String search, String sort) {
+        if (team != null && team.isEmpty()) team = null;
+        if (position != null && position.isEmpty()) position = null;
+        if (search != null && search.isEmpty()) search = null;
+
         // 1. Get all picks for this game
-        List<DraftPick> picks = draftPickRepository.findByFantasyGameSeq(gameSeq);
-        Set<Long> pickedPlayerSeqs = picks.stream()
-                .map(DraftPick::getFantasyPlayerSeq)
-                .collect(Collectors.toSet());
+        Set<Long> pickedPlayerSeqs;
+        if (gameSeq == null || gameSeq == 0L) {
+            pickedPlayerSeqs = Collections.emptySet();
+        } else {
+            List<DraftPick> picks = draftPickRepository.findByFantasyGameSeq(gameSeq);
+            pickedPlayerSeqs = picks.stream()
+                    .map(DraftPick::getFantasyPlayerSeq)
+                    .collect(Collectors.toSet());
+        }
 
         // 2. Get filtered players from DB
         List<FantasyPlayer> filteredPlayers = fantasyPlayerRepository.findPlayers(team, position, search);

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -56,7 +56,7 @@ public class FantasyDraftService {
 
         // Check if already joined
         if (fantasyParticipantRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId).isPresent()) {
-            throw new IllegalStateException("Player already joined this game");
+            throw new IllegalStateException("이미 참여 신청을 완료했습니다");
         }
 
         FantasyParticipant participant = FantasyParticipant.builder()
@@ -119,13 +119,13 @@ public class FantasyDraftService {
                 .orElseThrow(() -> new IllegalArgumentException("Invalid Game Seq"));
 
         if (game.getStatus() != FantasyGame.GameStatus.DRAFTING) {
-            throw new IllegalStateException("Game is not in DRAFTING status");
+            throw new IllegalStateException("드래프트 중이 아닙니다");
         }
 
         // Check Turn
         NextPickInfo nextPick = getNextPickInfo(game);
         if (!nextPick.pickerId.equals(request.getPlayerId())) {
-            throw new IllegalStateException("It is not your turn. Current turn: " + nextPick.pickerId);
+            throw new IllegalStateException("당신의 차례가 아닙니다: " + nextPick.pickerId);
         }
 
         // 2. Check availability
@@ -134,7 +134,7 @@ public class FantasyDraftService {
                 request.getFantasyPlayerSeq()
         );
         if (isPicked) {
-            throw new IllegalStateException("Player already picked");
+            throw new IllegalStateException("이미 뽑힌 선수입니다");
         }
 
         // 3. Validate Rules
@@ -155,7 +155,7 @@ public class FantasyDraftService {
             int currentCost = currentTeam.stream().mapToInt(p -> p.getCost() == null ? 0 : p.getCost()).sum();
             int newPlayerCost = targetPlayer.getCost() == null ? 0 : targetPlayer.getCost();
             if (currentCost + newPlayerCost > game.getSalaryCap()) {
-                throw new IllegalStateException("Salary Cap Exceeded: " + (currentCost + newPlayerCost) + " / " + game.getSalaryCap());
+                throw new IllegalStateException("샐캡 초과: " + (currentCost + newPlayerCost) + " / " + game.getSalaryCap());
             }
         }
 
@@ -319,11 +319,11 @@ public class FantasyDraftService {
             // But if user has 4 SPs, 5th SP -> Bench.
             long spCount = occupied.stream().filter(p -> p.equals("SP")).count();
             long rpCount = occupied.stream().filter(p -> p.equals("RP")).count();
-            long clCount = occupied.stream().filter(p -> p.equals("CL") || p.equals("CP")).count();
+            long clCount = occupied.stream().filter(p -> p.equals("CL")).count();
 
             if (primaryPos.equals("SP")) return spCount < 4 ? "SP" : null;
             if (primaryPos.equals("RP")) return rpCount < 4 ? "RP" : null;
-            if (primaryPos.equals("CL") || primaryPos.equals("CP")) return clCount < 1 ? "CL" : null;
+            if (primaryPos.equals("CL")) return clCount < 1 ? "CL" : null;
             return null; // Bench
         } else {
             // Batter Logic
@@ -340,7 +340,7 @@ public class FantasyDraftService {
     }
 
     private boolean isPitcher(String pos) {
-        return pos.equals("SP") || pos.equals("RP") || pos.equals("CL") || pos.equals("CP");
+        return pos.equals("SP") || pos.equals("RP") || pos.equals("CL");
     }
 
     @Transactional

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -271,7 +271,7 @@ public class FantasyGameService {
 
             for (FantasyPlayer fp : roster) {
                 String pos = fp.getPosition();
-                boolean isPitcher = pos.contains("SP") || pos.contains("RP") || pos.contains("CP") || pos.contains("CL") || pos.equals("P");
+                boolean isPitcher = pos.contains("SP") || pos.contains("RP") || pos.contains("CL") || pos.equals("P");
                 if (isPitcher) {
                     pitchers.add(fp.getName());
                 } else {

--- a/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
@@ -67,7 +67,7 @@ public class Rule1Validator implements DraftRuleValidator {
                         pref.toLowerCase().contains(playerTeam.toLowerCase());
 
                 if (!match) {
-                    throw new IllegalStateException("First pick must be from preferred team: " + participant.getPreferredTeam());
+                    throw new IllegalStateException("1차 지명 룰 위반: " + participant.getPreferredTeam());
                 }
             }
         }
@@ -77,7 +77,7 @@ public class Rule1Validator implements DraftRuleValidator {
         combinedTeam.add(newPlayer);
 
         if (!canFit(combinedTeam)) {
-            throw new IllegalStateException("Drafting this player violates roster composition rules.");
+            throw new IllegalStateException("이 선수를 뽑으면 로스터 포지션을 채울 수 없습니다.");
         }
 
         // Foreigner Limits Check
@@ -138,7 +138,7 @@ public class Rule1Validator implements DraftRuleValidator {
              List<String> sortedMissing = new ArrayList<>(missingTeamsSet);
              Collections.sort(sortedMissing);
              String missingStr = String.join(", ", sortedMissing);
-             throw new IllegalStateException("Must pick players from all 10 teams. Missing: [" + missingStr + "]");
+             throw new IllegalStateException("10개 구단에서 각각 한명씩 뽑아야합니다. 빠진 팀 : [" + missingStr + "]");
         }
     }
 
@@ -154,10 +154,10 @@ public class Rule1Validator implements DraftRuleValidator {
         }).count();
 
         if (type1Count > MAX_TYPE1_FOREIGNERS) {
-            throw new IllegalStateException("Cannot draft more than " + MAX_TYPE1_FOREIGNERS + " Foreigners (TYPE_1).");
+            throw new IllegalStateException("외국인 용병 제한 " + MAX_TYPE1_FOREIGNERS + " 명을 넘게 선발할 수 없습니다.");
         }
         if (type2Count > MAX_TYPE2_FOREIGNERS) {
-            throw new IllegalStateException("Cannot draft more than " + MAX_TYPE2_FOREIGNERS + " Asian Quarter (TYPE_2).");
+            throw new IllegalStateException("아시아 쿼터 제한" + MAX_TYPE2_FOREIGNERS + " 명을 넘게 선발할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
@@ -47,6 +47,25 @@ public class Rule1Validator implements DraftRuleValidator {
 
     @Override
     public void validate(FantasyGame game, FantasyPlayer newPlayer, List<FantasyPlayer> currentTeam, FantasyParticipant participant) {
+        // Check First Pick Rule Option
+        if (Boolean.TRUE.equals(game.getUseFirstPickRule())) {
+            if (currentTeam.isEmpty()) {
+                if (participant == null || participant.getPreferredTeam() == null) {
+                    throw new IllegalStateException("Preferred team not set for participant");
+                }
+
+                String pref = participant.getPreferredTeam().trim();
+                String playerTeam = newPlayer.getTeam().trim();
+
+                boolean match = playerTeam.toLowerCase().contains(pref.toLowerCase()) ||
+                        pref.toLowerCase().contains(playerTeam.toLowerCase());
+
+                if (!match) {
+                    throw new IllegalStateException("First pick must be from preferred team: " + participant.getPreferredTeam());
+                }
+            }
+        }
+
         // Rule 1 Checks (Composition)
         List<FantasyPlayer> combinedTeam = new ArrayList<>(currentTeam);
         combinedTeam.add(newPlayer);

--- a/src/main/resources/static/css/fantasy.css
+++ b/src/main/resources/static/css/fantasy.css
@@ -278,6 +278,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    position: relative; /* Anchor for tooltip */
 }
 
 .pitcher-slot.filled {
@@ -379,6 +380,54 @@
     box-shadow: 0 0 10px rgba(0, 123, 255, 0.5);
     cursor: pointer;
 }
+
+/* Player Card Tooltip */
+.player-card-tooltip {
+    display: none;
+    position: absolute;
+    top: 100%; /* Show below the element */
+    left: 50%;
+    transform: translateX(-50%);
+    width: 200px;
+    background-color: white;
+    border: 1px solid #ccc;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+    padding: 10px;
+    border-radius: 6px;
+    z-index: 1000;
+    text-align: left;
+    pointer-events: none; /* Prevent flickering on hover */
+    margin-top: 5px;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: #333;
+}
+
+/* Adjust position for field players to be above if low on screen?
+   For now standard bottom is fine, but maybe add arrow? */
+.player-card-tooltip::after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent white transparent;
+}
+
+.field-position:hover .player-card-tooltip,
+.pitcher-slot:hover .player-card-tooltip {
+    display: block;
+}
+
+.field-position:hover {
+    z-index: 1100; /* Ensure hovered card is on top of others */
+}
+
+/* Special adjustment for tooltip inside field positions to override transforms if needed.
+   The field-position uses transform: translate(-50%, -50%).
+   The tooltip's left:50% + translateX(-50%) centers it relative to the field-position's box. */
 
 /* Modal Specifics */
 .details-section {

--- a/src/main/resources/static/css/fantasy.css
+++ b/src/main/resources/static/css/fantasy.css
@@ -345,7 +345,7 @@
 /* Position Colors */
 .pos-sp { color: #D60C0C; font-weight: bold; } /* Red */
 .pos-rp { color: #FF9800; font-weight: bold; } /* Orange */
-.pos-cp { color: #9C27B0; font-weight: bold; } /* Purple */
+.pos-cl { color: #9C27B0; font-weight: bold; } /* Purple */
 .pos-c  { color: #795548; font-weight: bold; } /* Brown */
 .pos-if { color: #007bff; font-weight: bold; } /* Blue */
 .pos-of { color: #28a745; font-weight: bold; } /* Green */

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -225,7 +225,7 @@
                 }
 
                 updateUI();
-                loadAvailablePlayers();
+                loadAvailablePlayers(true); // Force refresh on init/resume
                 loadMyPicks();
             });
         }

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -165,6 +165,10 @@
             currentCost: 0
         };
 
+        // Client-side cache
+        let allAvailablePlayers = [];
+        let isPlayersLoaded = false;
+
         $(document).ready(function() {
             initGame();
             connectWebSocket();
@@ -179,10 +183,10 @@
             });
 
             $('#filter-team, #filter-position, #sort-order').change(function() {
-                loadAvailablePlayers();
+                renderPlayers(); // Local filter
             });
             $('#search-player').on('keyup', function(e) {
-                if (e.key === 'Enter') loadAvailablePlayers();
+                renderPlayers(); // Local search
             });
 
             setInterval(updateTimer, 1000);
@@ -317,13 +321,19 @@
                 gameState.nextPickDeadline = event.nextPickDeadline;
                 gameState.round = event.round;
                 updateUI();
-                loadAvailablePlayers();
+                // Force reload full list on start to be safe
+                loadAvailablePlayers(true);
             } else if (event.type === 'PICK') {
                 gameState.nextPickerId = event.nextPickerId;
                 gameState.nextPickDeadline = event.nextPickDeadline;
                 gameState.round = event.round;
+
+                // Optimistic Update: Remove player from local cache
+                removePlayerFromCache(event.fantasyPlayerSeq);
+
                 updateUI();
-                loadAvailablePlayers();
+                renderPlayers(); // Re-render with updated state (turn change etc)
+
                 if (String(event.playerId) === String(userId)) {
                     loadMyPicks();
                 }
@@ -332,79 +342,132 @@
                 gameState.nextPickerId = null;
                 gameState.nextPickDeadline = null;
                 alert("Draft Completed!");
+
+                removePlayerFromCache(event.fantasyPlayerSeq);
+
                 updateUI();
-                loadAvailablePlayers();
+                renderPlayers();
                 if (String(event.playerId) === String(userId)) {
                     loadMyPicks();
                 }
             }
         }
 
-        function loadAvailablePlayers() {
-            const team = $('#filter-team').val();
-            const position = $('#filter-position').val();
-            const search = $('#search-player').val();
-            const sort = $('#sort-order').val();
+        function removePlayerFromCache(seq) {
+            allAvailablePlayers = allAvailablePlayers.filter(p => p.seq !== seq);
+        }
 
-            let query = `?`;
-            if (team) query += `team=${encodeURIComponent(team)}&`;
-            if (position) query += `position=${encodeURIComponent(position)}&`;
-            if (search) query += `search=${encodeURIComponent(search)}&`;
-            if (sort) query += `sort=${encodeURIComponent(sort)}&`;
+        // Fetch all players once (or force refresh)
+        function loadAvailablePlayers(force = false) {
+            if (isPlayersLoaded && !force) {
+                renderPlayers();
+                return;
+            }
 
-            $.get(`/apis/v1/fantasy/games/${gameSeq}/available-players${query}`, function(data) {
-                const tbody = $('#available-players-body');
-                tbody.empty();
+            // Fetch ALL players (no server-side filters)
+            $.get(`/apis/v1/fantasy/games/${gameSeq}/available-players`, function(data) {
+                allAvailablePlayers = data;
+                isPlayersLoaded = true;
+                renderPlayers();
+            });
+        }
 
-                const isMyTurn = (String(gameState.nextPickerId) === String(userId));
-                const isRound1 = (gameState.round === 1);
+        function renderPlayers() {
+            const teamFilter = $('#filter-team').val();
+            const posFilter = $('#filter-position').val();
+            const searchText = $('#search-player').val().toLowerCase();
+            const sortOrder = $('#sort-order').val();
 
-                data.forEach(player => {
-                    const firstPos = player.position ? player.position.split(',')[0].trim().toLowerCase() : '';
-                    let cssClass = 'pos-' + firstPos;
-                    if(firstPos === 'cl') cssClass = 'pos-cp';
-
-                    let disabled = !isMyTurn;
-                    let btnText = "Draft";
-
-                    // Rule 2 Check
-                    if (isMyTurn && gameState.ruleType === 'RULE_2' && isRound1) {
-                         // Check team
-                         const myTeam = (gameState.myPreferredTeam || "").toLowerCase().trim();
-                         const pTeam = (player.team || "").toLowerCase().trim();
-                         if (myTeam && !pTeam.includes(myTeam) && !myTeam.includes(pTeam)) {
-                             disabled = true;
-                             btnText = "Restricted"; // Or just keep disabled
-                         }
+            // Filter
+            let filtered = allAvailablePlayers.filter(p => {
+                if (teamFilter && p.team !== teamFilter) return false;
+                if (posFilter) {
+                    // Simple check: does position string contain it?
+                    // Or exact match? Server was exact for 'C', LIKE for others.
+                    // Let's implement robust check similar to server
+                    if (posFilter === 'C') {
+                        // Must be exactly C or start with C, but not CF/CL/CP?
+                        // Server logic: "C" -> exact "C".
+                        // Client logic: p.position is "C" or "C, 1B".
+                        const positions = p.position.split(',').map(s => s.trim());
+                        if (!positions.includes('C')) return false;
+                    } else {
+                        if (!p.position.includes(posFilter)) return false;
                     }
+                }
+                if (searchText && !p.name.toLowerCase().includes(searchText)) return false;
+                return true;
+            });
 
-                    // Salary Cap Check
-                    if (isMyTurn && gameState.salaryCap && gameState.salaryCap > 0) {
-                        const currentCost = gameState.currentCost || 0;
-                        const playerCost = player.cost || 0;
-                        if (currentCost + playerCost > gameState.salaryCap) {
-                            disabled = true;
-                            btnText = "Over Cap";
-                        }
+            // Sort
+            if (sortOrder === 'cost_desc') {
+                filtered.sort((a, b) => (b.cost || 0) - (a.cost || 0));
+            } else if (sortOrder === 'cost_asc') {
+                filtered.sort((a, b) => (a.cost || 0) - (b.cost || 0));
+            }
+
+            const tbody = $('#available-players-body');
+            tbody.empty();
+
+            const isMyTurn = (String(gameState.nextPickerId) === String(userId));
+            const isRound1 = (gameState.round === 1);
+
+            // Limit render to improve performance (e.g. 100 items) if list is huge?
+            // For KBO ~600 players, it's fine to render all or maybe top 100.
+            const renderList = filtered.slice(0, 100);
+
+            renderList.forEach(player => {
+                const firstPos = player.position ? player.position.split(',')[0].trim().toLowerCase() : '';
+                let cssClass = 'pos-' + firstPos;
+                if(firstPos === 'cl') cssClass = 'pos-cp';
+
+                let disabled = !isMyTurn;
+                let btnText = "Draft";
+
+                // Rule 2 Check
+                if (isMyTurn && gameState.ruleType === 'RULE_2' && isRound1) {
+                     // Check team
+                     const myTeam = (gameState.myPreferredTeam || "").toLowerCase().trim();
+                     const pTeam = (player.team || "").toLowerCase().trim();
+                     if (myTeam && !pTeam.includes(myTeam) && !myTeam.includes(pTeam)) {
+                         disabled = true;
+                         btnText = "Restricted"; // Or just keep disabled
+                     }
+                }
+
+                // First Pick Rule (Rule 1 Option) Check
+                // We need to know if Rule 1 Option is enabled.
+                // Currently gameState doesn't explicitly store useFirstPickRule flag but backend sends RuleType.
+                // Assuming useFirstPickRule is property of game, we should fetch it in initGame.
+                // But for now, let's skip strict client-side check if we lack the flag, server will block.
+                // Or user can add the flag to initGame details.
+
+                // Salary Cap Check
+                if (isMyTurn && gameState.salaryCap && gameState.salaryCap > 0) {
+                    const currentCost = gameState.currentCost || 0;
+                    const playerCost = player.cost || 0;
+                    if (currentCost + playerCost > gameState.salaryCap) {
+                        disabled = true;
+                        btnText = "Over Cap";
                     }
+                }
 
-                    tbody.append(`
-                        <tr>
-                            <td>${player.name}</td>
-                            <td><span class="position-badge ${cssClass}">${player.position}</span></td>
-                            <td><span class="team-badge">${player.team}</span></td>
-                            <td>${player.stats || '-'}</td>
-                            <td>${player.cost || 0}</td>
-                            <td>
-                                <button class="btn-draft ${disabled ? 'disabled-btn' : ''}"
-                                        onclick="draftPlayer(${player.seq})"
-                                        ${disabled ? 'disabled' : ''}>
-                                    ${btnText}
-                                </button>
-                            </td>
-                        </tr>
-                    `);
-                });
+                tbody.append(`
+                    <tr>
+                        <td>${player.name}</td>
+                        <td><span class="position-badge ${cssClass}">${player.position}</span></td>
+                        <td><span class="team-badge">${player.team}</span></td>
+                        <td>${player.stats || '-'}</td>
+                        <td>${player.cost || 0}</td>
+                        <td>
+                            <button class="btn-draft ${disabled ? 'disabled-btn' : ''}"
+                                    onclick="draftPlayer(${player.seq})"
+                                    ${disabled ? 'disabled' : ''}>
+                                ${btnText}
+                            </button>
+                        </td>
+                    </tr>
+                `);
             });
         }
 

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -386,7 +386,7 @@
                     // Or exact match? Server was exact for 'C', LIKE for others.
                     // Let's implement robust check similar to server
                     if (posFilter === 'C') {
-                        // Must be exactly C or start with C, but not CF/CL/CP?
+                        // Must be exactly C or start with C, but not CF/CL?
                         // Server logic: "C" -> exact "C".
                         // Client logic: p.position is "C" or "C, 1B".
                         const positions = p.position.split(',').map(s => s.trim());
@@ -419,7 +419,7 @@
             renderList.forEach(player => {
                 const firstPos = player.position ? player.position.split(',')[0].trim().toLowerCase() : '';
                 let cssClass = 'pos-' + firstPos;
-                if(firstPos === 'cl') cssClass = 'pos-cp';
+                if(firstPos === 'cl') cssClass = 'pos-cl';
 
                 let disabled = !isMyTurn;
                 let btnText = "Draft";
@@ -479,7 +479,7 @@
                 data.forEach(player => {
                     const firstPos = player.position ? player.position.split(',')[0].trim().toLowerCase() : '';
                     let cssClass = 'pos-' + firstPos;
-                    if(firstPos === 'cl') cssClass = 'pos-cp';
+                    if(firstPos === 'cl') cssClass = 'pos-cl';
                     totalCost += (player.cost || 0);
 
                     list.append(`

--- a/src/main/resources/templates/fantasy/index.html
+++ b/src/main/resources/templates/fantasy/index.html
@@ -98,7 +98,7 @@
                                 <div class="pitcher-slot" id="d-slot-RP-2"><span class="pitcher-role">RP</span><span class="player-name">-</span></div>
                                 <div class="pitcher-slot" id="d-slot-RP-3"><span class="pitcher-role">RP</span><span class="player-name">-</span></div>
                                 <div class="pitcher-slot" id="d-slot-RP-4"><span class="pitcher-role">RP</span><span class="player-name">-</span></div>
-                                <div class="pitcher-slot" id="d-slot-CL-1"><span class="pitcher-role">CP</span><span class="player-name">-</span></div>
+                                <div class="pitcher-slot" id="d-slot-CL-1"><span class="pitcher-role">CL</span><span class="player-name">-</span></div>
                             </div>
                         </div>
                     </div>
@@ -316,10 +316,10 @@
             roster.forEach(p => {
                 // Use assignedPosition if available
                 if (p.assignedPosition) {
-                    if (['SP', 'RP', 'CL', 'CP'].includes(p.assignedPosition)) {
+                    if (['SP', 'RP', 'CL'].includes(p.assignedPosition)) {
                          if (p.assignedPosition === 'SP') assignDetailPitcher('SP', spCount, p);
                          else if (p.assignedPosition === 'RP') assignDetailPitcher('RP', rpCount, p);
-                         else if (p.assignedPosition === 'CL' || p.assignedPosition === 'CP') fillDetailPitcherSlot('CL-1', p);
+                         else if (p.assignedPosition === 'CL') fillDetailPitcherSlot('CL-1', p);
                     } else {
                          fillDetailSlot(p.assignedPosition, p);
                     }
@@ -335,7 +335,7 @@
         }
 
         function isPitcher(pos) {
-            return ['SP', 'RP', 'CP', 'CL'].includes(pos);
+            return ['SP', 'RP', 'CL'].includes(pos);
         }
 
         function fillDetailSlot(pos, player) {

--- a/src/main/resources/templates/fantasy/my-team.html
+++ b/src/main/resources/templates/fantasy/my-team.html
@@ -239,6 +239,7 @@
             if (isField) slot.find('.player-team').remove();
             else slot.removeClass('filled');
             slot.removeClass('invalid-position'); // Reset validation state
+            slot.find('.player-card-tooltip').remove(); // Clear tooltip
 
             if (player) {
                 if (isField) {
@@ -248,6 +249,21 @@
                     nameElem.text(`${player.name} (${player.team})`);
                     slot.addClass('filled');
                 }
+
+                // Add Tooltip
+                const tooltipHtml = `
+                    <div class="player-card-tooltip">
+                        <div style="font-weight:bold; border-bottom:1px solid #eee; margin-bottom:5px; padding-bottom:3px;">
+                            ${player.name} <span style="font-weight:normal; font-size:0.8rem; color:#666;">(${player.team})</span>
+                        </div>
+                        <div><strong>Pos:</strong> ${player.position}</div>
+                        <div><strong>Cost:</strong> ${player.cost || 0}</div>
+                        <div style="margin-top:5px; font-size:0.8rem; color:#555;">
+                            <strong>Stats:</strong><br>${player.stats || '-'}
+                        </div>
+                    </div>
+                `;
+                slot.append(tooltipHtml);
             }
         }
 

--- a/src/main/resources/templates/fantasy/my-team.html
+++ b/src/main/resources/templates/fantasy/my-team.html
@@ -95,7 +95,7 @@
                     <div class="pitcher-slot" id="slot-RP-4"><span class="pitcher-role">RP</span><span class="player-name">-</span></div>
 
                     <!-- CL Slot -->
-                    <div class="pitcher-slot" id="slot-CL-1"><span class="pitcher-role">CP</span><span class="player-name">-</span></div>
+                    <div class="pitcher-slot" id="slot-CL-1"><span class="pitcher-role">CL</span><span class="player-name">-</span></div>
                 </div>
             </div>
             <div style="text-align: right; margin-bottom: 20px;">
@@ -202,9 +202,6 @@
             const validPositions = player.position.split(',').map(s => s.trim());
 
             // Map requiredPos to equivalents
-            if (requiredPos === 'CL' && validPositions.includes('CP')) return true;
-            if (requiredPos === 'CP' && validPositions.includes('CL')) return true;
-
             if (validPositions.includes(requiredPos)) return true;
 
             // DH Check
@@ -214,7 +211,7 @@
         }
 
         function isPitcher(pos) {
-            return ['SP', 'RP', 'CP', 'CL'].includes(pos);
+            return ['SP', 'RP', 'CL'].includes(pos);
         }
 
         function swapSlots(slotA, slotB) {
@@ -329,7 +326,7 @@
                             if (assignPitcher('SP', spCount, p)) placed = true;
                         } else if (ap === 'RP') {
                             if (assignPitcher('RP', rpCount, p)) placed = true;
-                        } else if (ap === 'CL' || ap === 'CP') {
+                        } else if (ap === 'CL') {
                             if (fillSlotById('slot-CL-1', p)) placed = true;
                         } else {
                             // Handle Specific Field (1B, C, etc)
@@ -403,7 +400,7 @@
         }
 
         function isPitcher(pos) {
-            return ['SP', 'RP', 'CP', 'CL'].includes(pos);
+            return ['SP', 'RP', 'CL'].includes(pos);
         }
 
         function fillSlot(pos, player) {

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceFilterTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceFilterTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,5 +44,20 @@ class FantasyDraftServiceFilterTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getName()).isEqualTo("Kim");
+    }
+
+    @Test
+    void getAvailablePlayers_shouldTreatEmptyStringsAsNull() {
+        Long gameSeq = 0L;
+        String team = "";
+        String pos = "";
+        String search = "";
+
+        // Expect findPlayers to be called with nulls
+        when(fantasyPlayerRepository.findPlayers(null, null, null)).thenReturn(Collections.emptyList());
+
+        fantasyDraftService.getAvailablePlayers(gameSeq, team, pos, search, null);
+
+        verify(fantasyPlayerRepository).findPlayers(null, null, null);
     }
 }

--- a/src/test/java/com/sayai/record/fantasy/service/rules/Rule1ValidatorFirstPickTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/rules/Rule1ValidatorFirstPickTest.java
@@ -1,0 +1,105 @@
+package com.sayai.record.fantasy.service.rules;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.entity.FantasyParticipant;
+import com.sayai.record.fantasy.entity.FantasyPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Rule1ValidatorFirstPickTest {
+
+    private Rule1Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new Rule1Validator();
+    }
+
+    @Test
+    void validate_shouldFail_whenFirstPickRuleEnabled_andPlayerNotFromPreferredTeam() {
+        FantasyGame game = FantasyGame.builder()
+                .useFirstPickRule(true)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder()
+                .preferredTeam("Doosan")
+                .build();
+        FantasyPlayer player = FantasyPlayer.builder()
+                .team("Samsung")
+                .position("1B")
+                .cost(10)
+                .build();
+        List<FantasyPlayer> currentTeam = Collections.emptyList();
+
+        assertThatThrownBy(() -> validator.validate(game, player, currentTeam, participant))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("First pick must be from preferred team");
+    }
+
+    @Test
+    void validate_shouldPass_whenFirstPickRuleEnabled_andPlayerFromPreferredTeam() {
+        FantasyGame game = FantasyGame.builder()
+                .useFirstPickRule(true)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder()
+                .preferredTeam("Doosan")
+                .build();
+        FantasyPlayer player = FantasyPlayer.builder()
+                .team("Doosan")
+                .position("1B")
+                .cost(10)
+                .build();
+        List<FantasyPlayer> currentTeam = Collections.emptyList();
+
+        assertThatCode(() -> validator.validate(game, player, currentTeam, participant))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_shouldPass_whenFirstPickRuleDisabled_andPlayerNotFromPreferredTeam() {
+        FantasyGame game = FantasyGame.builder()
+                .useFirstPickRule(false)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder()
+                .preferredTeam("Doosan")
+                .build();
+        FantasyPlayer player = FantasyPlayer.builder()
+                .team("Samsung")
+                .position("1B")
+                .cost(10)
+                .build();
+        List<FantasyPlayer> currentTeam = Collections.emptyList();
+
+        assertThatCode(() -> validator.validate(game, player, currentTeam, participant))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_shouldPass_whenNotFirstPick() {
+        FantasyGame game = FantasyGame.builder()
+                .useFirstPickRule(true)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder()
+                .preferredTeam("Doosan")
+                .build();
+
+        // Existing team with 1 player
+        List<FantasyPlayer> currentTeam = new ArrayList<>();
+        currentTeam.add(FantasyPlayer.builder().position("1B").team("Doosan").cost(10).build());
+
+        FantasyPlayer player = FantasyPlayer.builder()
+                .team("Samsung")
+                .position("2B")
+                .cost(10)
+                .build();
+
+        assertThatCode(() -> validator.validate(game, player, currentTeam, participant))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/sayai/record/fantasy/service/rules/Rule1ValidatorTeamRestrictionTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/rules/Rule1ValidatorTeamRestrictionTest.java
@@ -1,0 +1,130 @@
+package com.sayai.record.fantasy.service.rules;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.entity.FantasyParticipant;
+import com.sayai.record.fantasy.entity.FantasyPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Rule1ValidatorTeamRestrictionTest {
+
+    private Rule1Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new Rule1Validator();
+    }
+
+    @Test
+    void validate_shouldPass_whenTeamRestrictionDisabled_andViolatingCondition() {
+        FantasyGame game = FantasyGame.builder()
+                .useTeamRestriction(false)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder().build();
+
+        // Fill team with 9 players from "TeamA"
+        List<FantasyPlayer> currentTeam = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            currentTeam.add(FantasyPlayer.builder()
+                    .seq((long) i)
+                    .team("TeamA")
+                    .position("P") // Use generic position to pass composition check if possible, or assume mock works
+                    .cost(10)
+                    .build());
+        }
+
+        // Try to pick 10th player from "TeamA"
+        // Remaining slots: 18 - 10 = 8.
+        // Distinct teams: 1. Missing: 9.
+        // 8 < 9. Would fail if enabled.
+        FantasyPlayer player = FantasyPlayer.builder()
+                .team("TeamA")
+                .position("C")
+                .cost(10)
+                .build();
+
+        // Note: We need to ensure composition check passes.
+        // With 9 P and 1 C, it might fail composition if not careful.
+        // Rule1Validator checks backtracking.
+        // 18 slots total. 4 SP, 4 RP, 1 CL = 9 Pitchers.
+        // So 9 "P" might be parsed as SP/RP?
+        // Let's rely on the fact that Rule1Validator checks this.
+        // We should construct a valid team composition-wise.
+        // 4 SP, 4 RP, 1 CL = 9 Players. All from TeamA.
+        // 10th Player: C from TeamA.
+        // This is valid composition.
+
+        currentTeam.clear();
+        for(int i=0; i<4; i++) currentTeam.add(createPlayer("TeamA", "SP"));
+        for(int i=0; i<4; i++) currentTeam.add(createPlayer("TeamA", "RP"));
+        currentTeam.add(createPlayer("TeamA", "CL"));
+
+        FantasyPlayer finalPlayer = createPlayer("TeamA", "C");
+
+        assertThatCode(() -> validator.validate(game, finalPlayer, currentTeam, participant))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_shouldFail_whenTeamRestrictionEnabled_andPickMakesItImpossible() {
+        FantasyGame game = FantasyGame.builder()
+                .useTeamRestriction(true)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder().build();
+
+        // 9 Players from TeamA (4 SP, 4 RP, 1 CL)
+        List<FantasyPlayer> currentTeam = new ArrayList<>();
+        for(int i=0; i<4; i++) currentTeam.add(createPlayer("TeamA", "SP"));
+        for(int i=0; i<4; i++) currentTeam.add(createPlayer("TeamA", "RP"));
+        currentTeam.add(createPlayer("TeamA", "CL"));
+
+        // Try to pick 10th player from TeamA
+        // Remaining after this pick: 18 - 10 = 8.
+        // Distinct Teams: 1 (TeamA).
+        // Missing Teams: 9.
+        // 8 < 9 -> FAIL
+        FantasyPlayer player = createPlayer("TeamA", "C");
+
+        assertThatThrownBy(() -> validator.validate(game, player, currentTeam, participant))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Must pick players from at least 10 different teams");
+    }
+
+    @Test
+    void validate_shouldPass_whenTeamRestrictionEnabled_andPickKeepsPossibility() {
+        FantasyGame game = FantasyGame.builder()
+                .useTeamRestriction(true)
+                .build();
+        FantasyParticipant participant = FantasyParticipant.builder().build();
+
+        // 9 Players from TeamA
+        List<FantasyPlayer> currentTeam = new ArrayList<>();
+        for(int i=0; i<4; i++) currentTeam.add(createPlayer("TeamA", "SP"));
+        for(int i=0; i<4; i++) currentTeam.add(createPlayer("TeamA", "RP"));
+        currentTeam.add(createPlayer("TeamA", "CL"));
+
+        // Try to pick 10th player from TeamB
+        // Remaining after this pick: 8.
+        // Distinct Teams: 2 (TeamA, TeamB).
+        // Missing Teams: 8.
+        // 8 >= 8 -> PASS
+        FantasyPlayer player = createPlayer("TeamB", "C");
+
+        assertThatCode(() -> validator.validate(game, player, currentTeam, participant))
+                .doesNotThrowAnyException();
+    }
+
+    private FantasyPlayer createPlayer(String team, String position) {
+        return FantasyPlayer.builder()
+                .team(team)
+                .position(position)
+                .cost(10)
+                .build();
+    }
+}


### PR DESCRIPTION
Fixed an issue where the `available-players` API returned an empty list when `gameSeq` was 0 (or when accessed from the main player list). This was caused by the frontend sending empty strings ("") for filters like `team`, `position`, and `search`, which the repository query treated as literal values (e.g., matching `team = ""`) instead of ignoring them. 

The fix involves sanitizing these inputs to `null` in the service layer. Additionally, an optimization was added to skip the database query for draft picks when `gameSeq` is 0, as no picks exist in that context. A regression test was added to verify the fix.

---
*PR created automatically by Jules for task [2083213219946798484](https://jules.google.com/task/2083213219946798484) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable "first pick" requirement and optional team-restriction enforcing minimum distinct teams.
  * Client-side caching with in-memory filtering/rendering of available players and optimistic draft updates.
  * Player-card tooltips showing name, team, position, cost, and stats; CL slot label updated.

* **Bug Fixes**
  * Treat empty search/team/position inputs as no filter.
  * Safer handling so players aren’t incorrectly shown as picked.

* **Localization**
  * Several draft-related messages translated to Korean.

* **Tests**
  * Added tests for empty-input normalization, first-pick and team-restriction rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->