### PR TITLE
⚡ Optimize FantasyScoringService N+1 issue

### DIFF
--- a/src/test/java/com/sayai/record/fantasy/service/FantasyScoringServiceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyScoringServiceTest.java
@@ -1,0 +1,75 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.dto.FantasyScoreDto;
+import com.sayai.record.fantasy.entity.FantasyRotisserieScore;
+import com.sayai.record.fantasy.repository.FantasyRotisserieScoreRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+public class FantasyScoringServiceTest {
+
+    @Autowired
+    private FantasyScoringService scoringService;
+
+    @Autowired
+    private FantasyRotisserieScoreRepository scoreRepository;
+
+    @Test
+    public void testSaveAndCalculateScores() {
+        Long gameSeq = 999L;
+        Integer round = 1;
+        int playerCount = 10;
+
+        // 1. Pre-populate DB with existing scores
+        List<FantasyRotisserieScore> initialScores = new ArrayList<>();
+        for (long i = 1; i <= playerCount; i++) {
+            initialScores.add(FantasyRotisserieScore.builder()
+                    .fantasyGameSeq(gameSeq)
+                    .playerId(i)
+                    .round(round)
+                    .avg(0.250)
+                    .hr(0)
+                    .rbi(0)
+                    .build());
+        }
+        scoreRepository.saveAll(initialScores);
+        scoreRepository.flush();
+
+        // 2. Prepare input DTOs for update
+        List<FantasyScoreDto> inputScores = new ArrayList<>();
+        for (long i = 1; i <= playerCount; i++) {
+            inputScores.add(FantasyScoreDto.builder()
+                    .fantasyGameSeq(gameSeq)
+                    .playerId(i)
+                    .round(round)
+                    .avg(0.300) // Changed value
+                    .hr(1)
+                    .rbi(5)
+                    .soBatter(2)
+                    .sb(1)
+                    .wins(0)
+                    .era(3.5)
+                    .soPitcher(5)
+                    .whip(1.1)
+                    .saves(0)
+                    .build());
+        }
+
+        // 3. Execute
+        scoringService.saveAndCalculateScores(gameSeq, round, inputScores);
+
+        // 4. Verify Update
+        List<FantasyRotisserieScore> updatedScores = scoreRepository.findByFantasyGameSeqAndRound(gameSeq, round);
+        assertEquals(playerCount, updatedScores.size());
+        assertEquals(0.300, updatedScores.get(0).getAvg(), 0.001);
+    }
+}


### PR DESCRIPTION
This PR addresses an N+1 query performance issue in `FantasyScoringService.saveAndCalculateScores`.

**Changes:**
- Replaced the loop-based `findByFantasyGameSeqAndPlayerIdAndRound` with a single `findByFantasyGameSeqAndRound` bulk fetch.
- Implemented a `Map` lookup strategy to update existing scores or create new ones in memory.
- Added `FantasyScoringServiceTest` to ensure the logic remains correct after refactoring.

**Performance Impact:**
- Reduced database round-trips from O(N) to O(1) for score updates.
- Verified functionality with a new integration test.
- Confirmed that existing test failures in the suite are unrelated to this change.

---
*PR created automatically by Jules for task [14983303804300281845](https://jules.google.com/task/14983303804300281845) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved fantasy scoring calculation efficiency by streamlining how score data is retrieved and processed during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->