### PR TITLE
Handle Null Scores in FantasyScoringService

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/service/FantasyScoringService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyScoringService.java
@@ -182,8 +182,13 @@ public class FantasyScoringService {
             i = j;
         }
 
-        // Handle nulls (optional: set 0 points and last rank?)
-        // Currently they just stay null.
+        // Handle nulls
+        for (FantasyRotisserieScore s : scores) {
+            if (valueExtractor.apply(s) == null) {
+                rankSetter.accept(s, totalParticipants);
+                pointSetter.accept(s, 0.0);
+            }
+        }
     }
 
     private FantasyScoreDto convertToDto(FantasyRotisserieScore entity) {

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyScoringServiceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyScoringServiceTest.java
@@ -72,4 +72,68 @@ public class FantasyScoringServiceTest {
         assertEquals(playerCount, updatedScores.size());
         assertEquals(0.300, updatedScores.get(0).getAvg(), 0.001);
     }
+
+    @Test
+    public void testNullScoreHandling() {
+        Long gameSeq = 888L;
+        Integer round = 1;
+        int playerCount = 3;
+
+        // 1. Create 3 players
+        List<FantasyRotisserieScore> initialScores = new ArrayList<>();
+        for (long i = 1; i <= playerCount; i++) {
+            initialScores.add(FantasyRotisserieScore.builder()
+                    .fantasyGameSeq(gameSeq)
+                    .playerId(i)
+                    .round(round)
+                    .build());
+        }
+        scoreRepository.saveAll(initialScores);
+        scoreRepository.flush();
+
+        // 2. Input DTOs
+        // Player 1: Best (AVG 0.350)
+        // Player 2: Middle (AVG 0.250)
+        // Player 3: Null (AVG null)
+        List<FantasyScoreDto> inputScores = new ArrayList<>();
+
+        inputScores.add(FantasyScoreDto.builder().fantasyGameSeq(gameSeq).playerId(1L).round(round)
+                .avg(0.350).rbi(10).hr(5).soBatter(10).sb(5)
+                .wins(1).era(2.00).soPitcher(10).whip(1.00).saves(1)
+                .build());
+
+        inputScores.add(FantasyScoreDto.builder().fantasyGameSeq(gameSeq).playerId(2L).round(round)
+                .avg(0.250).rbi(5).hr(2).soBatter(20).sb(2) // soBatter higher (worse)
+                .wins(0).era(4.00).soPitcher(5).whip(1.50).saves(0)
+                .build());
+
+        inputScores.add(FantasyScoreDto.builder().fantasyGameSeq(gameSeq).playerId(3L).round(round)
+                .avg(null).rbi(null).hr(null).soBatter(null).sb(null)
+                .wins(null).era(null).soPitcher(null).whip(null).saves(null)
+                .build());
+
+        // 3. Execute
+        scoringService.saveAndCalculateScores(gameSeq, round, inputScores);
+
+        // 4. Verify
+        List<FantasyRotisserieScore> scores = scoreRepository.findByFantasyGameSeqAndRound(gameSeq, round);
+
+        // Find by playerId
+        FantasyRotisserieScore p1 = scores.stream().filter(s -> s.getPlayerId() == 1L).findFirst().orElseThrow();
+        FantasyRotisserieScore p2 = scores.stream().filter(s -> s.getPlayerId() == 2L).findFirst().orElseThrow();
+        FantasyRotisserieScore p3 = scores.stream().filter(s -> s.getPlayerId() == 3L).findFirst().orElseThrow();
+
+        // Check AVG
+        // P1: Rank 1, Points (3-1+1)*10 = 30
+        assertEquals(1, p1.getRankAvg());
+        assertEquals(30.0, p1.getPointsAvg(), 0.01);
+
+        // P2: Rank 2, Points (3-2+1)*10 = 20
+        assertEquals(2, p2.getRankAvg());
+        assertEquals(20.0, p2.getPointsAvg(), 0.01);
+
+        // P3: Rank 3, Points 0 (As per requirement)
+        assertEquals(3, p3.getRankAvg(), "Null score should get last rank");
+        assertEquals(0.0, p3.getPointsAvg(), 0.01, "Null score should get 0 points");
+    }
 }


### PR DESCRIPTION
Implemented logic to handle null scores in `FantasyScoringService`. Previously, null scores were ignored and remained null. Now, any participant with a null score for a specific category is assigned the last rank (equal to the total number of participants) and 0 points, ensuring fair scoring. Verified with a new test case.

---
*PR created automatically by Jules for task [1095629782632096850](https://jules.google.com/task/1095629782632096850) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null score handling in fantasy scoring. Players with missing scores are now assigned the lowest rank and zero points, replacing previous behavior where they remained unprocessed.

* **Tests**
  * Added test coverage for null score handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->