### PR TITLE
Add Fantasy League News and Patch Notes Feature

### DIFF
--- a/src/main/java/com/sayai/record/admin/controller/AdminController.java
+++ b/src/main/java/com/sayai/record/admin/controller/AdminController.java
@@ -9,6 +9,8 @@ import com.sayai.record.fantasy.entity.FantasyParticipant;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import com.sayai.record.fantasy.service.FantasyGameService;
 import com.sayai.record.fantasy.service.FantasyScoringService;
+import com.sayai.record.fantasy.service.PostService;
+import com.sayai.record.fantasy.dto.PostDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -36,6 +38,14 @@ public class AdminController {
     private final PasswordEncoder passwordEncoder;
     private final AuthService authService;
     private final FantasyScoringService fantasyScoringService;
+    private final PostService postService;
+
+    // --- Post Management ---
+
+    @PostMapping("/posts")
+    public ResponseEntity<PostDto> createPost(@RequestBody PostDto dto) {
+        return ResponseEntity.ok(postService.createPost(dto));
+    }
 
     // --- Game Management ---
 

--- a/src/main/java/com/sayai/record/fantasy/controller/PostController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/PostController.java
@@ -16,7 +16,7 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public List<PostDto> getPosts(@RequestParam PostType type) {
+    public List<PostDto> getPosts(@RequestParam(name = "type") PostType type) {
         return postService.getPostsByType(type);
     }
 }

--- a/src/main/java/com/sayai/record/fantasy/controller/PostController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/PostController.java
@@ -16,7 +16,7 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public List<PostDto> getPosts(@RequestParam(name = "type") PostType type) {
+    public List<PostDto> getPosts(@RequestParam PostType type) {
         return postService.getPostsByType(type);
     }
 }

--- a/src/main/java/com/sayai/record/fantasy/controller/PostController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/PostController.java
@@ -1,0 +1,22 @@
+package com.sayai.record.fantasy.controller;
+
+import com.sayai.record.fantasy.dto.PostDto;
+import com.sayai.record.fantasy.entity.PostType;
+import com.sayai.record.fantasy.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/apis/v1/fantasy/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping
+    public List<PostDto> getPosts(@RequestParam PostType type) {
+        return postService.getPostsByType(type);
+    }
+}

--- a/src/main/java/com/sayai/record/fantasy/dto/PostDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/PostDto.java
@@ -1,0 +1,31 @@
+package com.sayai.record.fantasy.dto;
+
+import com.sayai.record.fantasy.entity.Post;
+import com.sayai.record.fantasy.entity.PostType;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDto {
+    private Long id;
+    private PostType type;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static PostDto from(Post post) {
+        return PostDto.builder()
+                .id(post.getId())
+                .type(post.getType())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sayai/record/fantasy/entity/Post.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/Post.java
@@ -1,0 +1,34 @@
+package com.sayai.record.fantasy.entity;
+
+import lombok.*;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "app_posts")
+@Entity
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PostType type;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/sayai/record/fantasy/entity/PostType.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/PostType.java
@@ -1,0 +1,6 @@
+package com.sayai.record.fantasy.entity;
+
+public enum PostType {
+    COLUMN,
+    PATCH_NOTE
+}

--- a/src/main/java/com/sayai/record/fantasy/repository/PostRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.sayai.record.fantasy.repository;
+
+import com.sayai.record.fantasy.entity.Post;
+import com.sayai.record.fantasy.entity.PostType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByTypeOrderByCreatedAtDesc(PostType type);
+}

--- a/src/main/java/com/sayai/record/fantasy/service/PostService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/PostService.java
@@ -1,0 +1,37 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.dto.PostDto;
+import com.sayai.record.fantasy.entity.Post;
+import com.sayai.record.fantasy.entity.PostType;
+import com.sayai.record.fantasy.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    @Transactional
+    public PostDto createPost(PostDto dto) {
+        Post post = Post.builder()
+                .type(dto.getType())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .build();
+        Post saved = postRepository.save(post);
+        return PostDto.from(saved);
+    }
+
+    public List<PostDto> getPostsByType(PostType type) {
+        return postRepository.findByTypeOrderByCreatedAtDesc(type).stream()
+                .map(PostDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/schema-updates.sql
+++ b/src/main/resources/schema-updates.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS app_posts (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  type VARCHAR(50),
+  title VARCHAR(255),
+  content TEXT,
+  created_at DATETIME
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/templates/fantasy/admin.html
+++ b/src/main/resources/templates/fantasy/admin.html
@@ -19,7 +19,10 @@
         <div class="admin-section" style="margin-bottom: 40px; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
                 <h2>Manage Games</h2>
-                <button onclick="openCreateModal()" class="btn btn-primary">Create New Game</button>
+                <div>
+                    <button onclick="openCreatePostModal()" class="btn btn-primary" style="margin-right: 10px; background-color: #17a2b8;">Patch Note / Column</button>
+                    <button onclick="openCreateModal()" class="btn btn-primary">Create New Game</button>
+                </div>
             </div>
 
             <table class="fantasy-table">
@@ -251,8 +254,46 @@
         </div>
     </div>
 
+    <!-- Create Post Modal -->
+    <div id="createPostModal" class="modal-overlay" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; justify-content: center; align-items: center;">
+        <div class="modal-container" style="background: white; padding: 20px; border-radius: 8px; width: 600px; max-width: 90%; max-height: 90vh; display: flex; flex-direction: column; position: relative;">
+            <div class="modal-header" style="border-bottom: 1px solid #eee; margin-bottom: 15px; display: flex; justify-content: space-between; flex-shrink: 0;">
+                <h3 style="margin: 0;">Create Post (Patch Note / Column)</h3>
+                <button onclick="closeCreatePostModal()" style="background:none; border:none; font-size: 1.5rem; cursor: pointer;">&times;</button>
+            </div>
+            <div class="modal-body" style="overflow-y: auto; flex-grow: 1;">
+                <form id="createPostForm">
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label style="font-weight: bold;">Type</label>
+                        <select name="type" class="form-control" style="width: 100%; padding: 8px;">
+                            <option value="PATCH_NOTE">Patch Note</option>
+                            <option value="COLUMN">Column (News)</option>
+                        </select>
+                    </div>
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label style="font-weight: bold;">Title</label>
+                        <input type="text" name="title" class="form-control" required style="width: 100%; padding: 8px;">
+                    </div>
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label style="font-weight: bold;">Content</label>
+                        <textarea name="content" class="form-control" rows="10" required style="width: 100%; padding: 8px; white-space: pre-wrap;"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary" style="width: 100%;">Create Post</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <script th:inline="javascript">
         /*<![CDATA[*/
+        function openCreatePostModal() {
+            $('#createPostModal').css('display', 'flex');
+        }
+
+        function closeCreatePostModal() {
+            $('#createPostModal').hide();
+        }
+
         function openCreateModal() {
             $('#createGameModal').css('display', 'flex');
         }
@@ -620,6 +661,30 @@
                         }
                     });
                 }
+            });
+
+            $('#createPostForm').submit(function(e) {
+                e.preventDefault();
+                const data = {
+                    type: $(this).find('select[name="type"]').val(),
+                    title: $(this).find('input[name="title"]').val(),
+                    content: $(this).find('textarea[name="content"]').val()
+                };
+
+                $.ajax({
+                    url: '/apis/v1/admin/posts',
+                    type: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(data),
+                    success: function() {
+                        alert('Post created!');
+                        closeCreatePostModal();
+                        $('#createPostForm')[0].reset();
+                    },
+                    error: function(xhr) {
+                        alert('Error: ' + (xhr.responseText || 'Failed'));
+                    }
+                });
             });
 
             $('#createGameForm').submit(function(e) {

--- a/src/main/resources/templates/fantasy/players.html
+++ b/src/main/resources/templates/fantasy/players.html
@@ -148,6 +148,7 @@
 
         function openNewsModal() {
              $('#newsModal').css('display', 'flex');
+             $('#newsBadge').hide();
              showNewsList(true);
         }
 

--- a/src/main/resources/templates/fantasy/players.html
+++ b/src/main/resources/templates/fantasy/players.html
@@ -14,7 +14,10 @@
                 <h1>선수 공시</h1>
             </div>
             <div>
-                <button onclick="openNewsModal()" class="btn btn-primary" style="background-color: #17a2b8; margin-right: 10px;">News</button>
+                <button onclick="openNewsModal()" class="btn btn-primary" style="background-color: #17a2b8; margin-right: 10px; position: relative;">
+                    News
+                    <span id="newsBadge" style="display:none; position: absolute; top: -5px; right: -5px; width: 10px; height: 10px; background-color: #dc3545; border-radius: 50%; border: 2px solid #fff;"></span>
+                </button>
                 <button onclick="openPatchLog()" class="btn btn-primary" style="background-color: #6c757d;">Patch Log</button>
             </div>
         </header>
@@ -264,8 +267,25 @@
             });
         }
 
+        function checkNewsNotification() {
+             $.get('/apis/v1/fantasy/posts?type=COLUMN', function(posts) {
+                 if (posts && posts.length > 0) {
+                     const lastPost = posts[0];
+                     const created = new Date(lastPost.createdAt);
+                     const now = new Date();
+                     const diffMs = now - created;
+                     const diffHours = diffMs / (1000 * 60 * 60);
+
+                     if (diffHours <= 24) {
+                         $('#newsBadge').show();
+                     }
+                 }
+             });
+        }
+
         $(document).ready(function() {
             loadGames();
+            checkNewsNotification();
 
             // Trigger search on enter in search input
             $('#searchInput').keypress(function(e) {

--- a/src/main/resources/templates/fantasy/players.html
+++ b/src/main/resources/templates/fantasy/players.html
@@ -13,7 +13,10 @@
             <div style="display:flex; align-items:center; gap: 20px;">
                 <h1>선수 공시</h1>
             </div>
-            <button onclick="openPatchLog()" class="btn btn-primary" style="background-color: #6c757d;">Patch Log</button>
+            <div>
+                <button onclick="openNewsModal()" class="btn btn-primary" style="background-color: #17a2b8; margin-right: 10px;">News</button>
+                <button onclick="openPatchLog()" class="btn btn-primary" style="background-color: #6c757d;">Patch Log</button>
+            </div>
         </header>
 
         <div th:replace="fragments/fantasy-nav :: nav(active='players')"></div>
@@ -83,26 +86,30 @@
                 <h3 style="margin: 0;">Patch Log</h3>
                 <button onclick="closePatchLog()" style="background:none; border:none; font-size: 1.5rem; cursor: pointer;">&times;</button>
             </div>
-            <div class="modal-body" style="overflow-y: auto; flex-grow: 1; line-height: 1.6;">
-                <h4>v1.1.0 - 샐러리캡 기능 추가</h4>
-                <ul>
-                    <li>모든 선수 코스트 산정</li>
-                    <li>신입 FA 계약 반영</li>
-                    <li>최근 3년 평균 WAR 을 기반으로 코스트 산정</li>
-                    <li>최근 3년 외인 평균 WAR 을 기반으로 신규 외인 코스트 산정</li>
-                    <li>이전 선수 데이터 초기화로 인한 드래프트 로그 조회 불가</li>
-                </ul>
-                <hr>
-                <h4>v1.0.0 - 최초 공시</h4>
-                <p>
-                    2025 규정타석/이닝 30% 플레이한 이력이 있는 모든 선수 등록<br>
-                    - 야수 수비포지션은 100이닝 이상 플레이한 포지션만 선정<br>
-                    - 너무 적은 이닝을 소화한 투수는 제외<br>
-                    - 몇몇 선수들을 특별히 추가
-                </p>
-                <!-- Add more dummy content to test scroll -->
-                <br><br><br><br><br><br><br><br><br><br><br><br>
-                <p>End of Log.</p>
+            <div id="patchLogBody" class="modal-body" style="overflow-y: auto; flex-grow: 1; line-height: 1.6;">
+                <!-- Content loaded via JS -->
+            </div>
+        </div>
+    </div>
+
+    <!-- News Modal -->
+    <div id="newsModal" class="modal-overlay" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; justify-content: center; align-items: center;">
+        <div class="modal-container" style="background: white; padding: 20px; border-radius: 8px; width: 600px; max-width: 90%; max-height: 80vh; display: flex; flex-direction: column;">
+            <div class="modal-header" style="border-bottom: 1px solid #eee; margin-bottom: 15px; display: flex; justify-content: space-between; flex-shrink: 0;">
+                <h3 style="margin: 0;">Fantasy Analysis (News)</h3>
+                <button onclick="closeNewsModal()" style="background:none; border:none; font-size: 1.5rem; cursor: pointer;">&times;</button>
+            </div>
+
+            <!-- List View -->
+            <div id="newsList" class="modal-body" style="overflow-y: auto; flex-grow: 1; line-height: 1.6;">
+                <!-- Content loaded via JS -->
+            </div>
+
+            <!-- Detail View -->
+            <div id="newsDetail" class="modal-body" style="display:none; overflow-y: auto; flex-grow: 1; line-height: 1.6; flex-direction: column;">
+                 <button onclick="showNewsList()" class="btn btn-secondary" style="margin-bottom: 15px; align-self: flex-start;">&larr; Back to List</button>
+                 <h4 id="newsDetailTitle" style="font-weight: bold; font-size: 1.2rem; margin-bottom: 20px; border-bottom: 1px solid #eee; padding-bottom: 10px;"></h4>
+                 <div id="newsDetailContent" style="white-space: pre-wrap; color: #333;"></div>
             </div>
         </div>
     </div>
@@ -111,10 +118,89 @@
         /*<![CDATA[*/
         function openPatchLog() {
             $('#patchLogModal').css('display', 'flex');
+            const body = $('#patchLogBody');
+            body.html('<p>Loading...</p>');
+
+            $.get('/apis/v1/fantasy/posts?type=PATCH_NOTE', function(posts) {
+                body.empty();
+                if (posts.length === 0) {
+                    body.html('<p>No patch notes found.</p>');
+                    return;
+                }
+                posts.forEach(p => {
+                    const div = $('<div>').css({'margin-bottom': '20px', 'border-bottom': '1px solid #eee', 'padding-bottom': '10px'});
+                    const title = $('<h4>').text(p.title);
+                    const content = $('<div>').css('white-space', 'pre-wrap').text(p.content);
+                    div.append(title).append(content);
+                    body.append(div);
+                });
+            });
         }
 
         function closePatchLog() {
             $('#patchLogModal').hide();
+        }
+
+        let cachedNews = [];
+
+        function openNewsModal() {
+             $('#newsModal').css('display', 'flex');
+             showNewsList(true);
+        }
+
+        function showNewsList(fetch = false) {
+             $('#newsDetail').hide();
+             $('#newsList').show();
+
+             if (fetch) {
+                 const body = $('#newsList');
+                 body.html('<p>Loading...</p>');
+
+                 $.get('/apis/v1/fantasy/posts?type=COLUMN', function(posts) {
+                     cachedNews = posts; // Store for detail view
+                     body.empty();
+                     if (posts.length === 0) {
+                         body.html('<p>No news found.</p>');
+                         return;
+                     }
+                     const list = $('<ul>').css({'list-style': 'none', 'padding': 0, 'margin': 0});
+                     posts.forEach((p, index) => {
+                         const li = $('<li>').css({
+                             'padding': '15px',
+                             'border-bottom': '1px solid #eee',
+                             'cursor': 'pointer'
+                         }).hover(
+                             function() { $(this).css('background-color', '#f8f9fa'); },
+                             function() { $(this).css('background-color', 'transparent'); }
+                         );
+
+                         const title = $('<div>').css({'font-weight': 'bold', 'font-size': '1.05rem'}).text(p.title);
+                         const date = $('<div>').css({'font-size': '0.85rem', 'color': '#888', 'margin-top': '5px'})
+                                      .text(p.createdAt ? new Date(p.createdAt).toLocaleDateString() : '');
+
+                         li.append(title).append(date);
+                         li.click(() => showNewsDetail(index));
+                         list.append(li);
+                     });
+                     body.append(list);
+                 });
+             }
+        }
+
+        function showNewsDetail(index) {
+            const p = cachedNews[index];
+            if (!p) return;
+
+            $('#newsList').hide();
+            $('#newsDetailTitle').text(p.title);
+            $('#newsDetailContent').text(p.content);
+            $('#newsDetail').css('display', 'flex');
+        }
+
+        function closeNewsModal() {
+            $('#newsModal').hide();
+            $('#newsDetail').hide();
+            $('#newsList').show();
         }
 
         function loadGames() {

--- a/src/test/java/com/sayai/record/fantasy/service/PostServiceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/PostServiceTest.java
@@ -1,0 +1,65 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.dto.PostDto;
+import com.sayai.record.fantasy.entity.Post;
+import com.sayai.record.fantasy.entity.PostType;
+import com.sayai.record.fantasy.repository.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    @Test
+    void createPost_SavesAndReturnsDto() {
+        PostDto input = PostDto.builder()
+                .type(PostType.COLUMN)
+                .title("New Column")
+                .content("Content")
+                .build();
+
+        Post saved = Post.builder()
+                .id(1L)
+                .type(PostType.COLUMN)
+                .title("New Column")
+                .content("Content")
+                .build();
+
+        when(postRepository.save(any(Post.class))).thenReturn(saved);
+
+        PostDto result = postService.createPost(input);
+
+        assertEquals(1L, result.getId());
+        assertEquals(PostType.COLUMN, result.getType());
+        assertEquals("New Column", result.getTitle());
+    }
+
+    @Test
+    void getPostsByType_ReturnsList() {
+        Post post1 = Post.builder().id(1L).type(PostType.PATCH_NOTE).title("Patch 1").build();
+        Post post2 = Post.builder().id(2L).type(PostType.PATCH_NOTE).title("Patch 2").build();
+
+        when(postRepository.findByTypeOrderByCreatedAtDesc(PostType.PATCH_NOTE))
+                .thenReturn(List.of(post1, post2));
+
+        List<PostDto> result = postService.getPostsByType(PostType.PATCH_NOTE);
+
+        assertEquals(2, result.size());
+        assertEquals("Patch 1", result.get(0).getTitle());
+    }
+}


### PR DESCRIPTION
Implemented a system for managing and displaying Fantasy League News (Columns) and Patch Notes. Admins can create these posts via the Admin Dashboard. Users can view Patch Notes in a simple list and News Columns in a Master-Detail interactive modal on the Player List page.

---
*PR created automatically by Jules for task [13678497088244609697](https://jules.google.com/task/13678497088244609697) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can create posts (Patch Notes & Columns) via admin UI and API.
  * Players can browse News (Columns) and Patch Logs in dynamic modals with list/detail navigation and a news badge.

* **Tests**
  * Added unit tests for post creation and retrieval.

* **Chores**
  * Database schema updated to store posts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->