### PR TITLE
Implement Rule 2 Validator and Roster Export Filter

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/controller/FantasyDraftController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/FantasyDraftController.java
@@ -31,8 +31,9 @@ public class FantasyDraftController {
             @RequestParam(name = "team", required = false) String team,
             @RequestParam(name = "position", required = false) String position,
             @RequestParam(name = "search", required = false) String search,
-            @RequestParam(name = "sort", required = false) String sort) {
-        return ResponseEntity.ok(fantasyDraftService.getAvailablePlayers(gameSeq, team, position, search, sort));
+            @RequestParam(name = "sort", required = false) String sort,
+            @RequestParam(name = "foreignerType", required = false) String foreignerType) {
+        return ResponseEntity.ok(fantasyDraftService.getAvailablePlayers(gameSeq, team, position, search, sort, foreignerType));
     }
 
     @PostMapping("/games/{gameSeq}/join")

--- a/src/main/java/com/sayai/record/fantasy/repository/FantasyPlayerRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/FantasyPlayerRepository.java
@@ -13,10 +13,12 @@ public interface FantasyPlayerRepository extends JpaRepository<FantasyPlayer, Lo
     @Query("SELECT p FROM FantasyPlayer p WHERE " +
             "(:team IS NULL OR p.team = :team) AND " +
             "(:position IS NULL OR (:position = 'C' AND p.position = 'C') OR (:position <> 'C' AND p.position LIKE CONCAT('%', :position, '%'))) AND " +
-            "(:search IS NULL OR p.name LIKE CONCAT('%', :search, '%'))")
+            "(:search IS NULL OR p.name LIKE CONCAT('%', :search, '%')) AND " +
+            "(:foreignerType IS NULL OR p.foreignerType = :foreignerType)")
     List<FantasyPlayer> findPlayers(@Param("team") String team,
                                     @Param("position") String position,
-                                    @Param("search") String search);
+                                    @Param("search") String search,
+                                    @Param("foreignerType") FantasyPlayer.ForeignerType foreignerType);
 
     List<FantasyPlayer> findBySeqNotIn(Collection<Long> seqs);
 }

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -442,8 +442,8 @@ public class FantasyDraftService {
         FantasyParticipant participant = fantasyParticipantRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId).orElseThrow();
         List<FantasyPlayer> candidates = available;
 
-        // Rule 2 Logic for Auto Pick
-        if (game.getRuleType() == FantasyGame.RuleType.RULE_2 && nextPick.round == 1) {
+        // First Pick Rule for Auto Pick (applies to both Rule 1 and Rule 2 if enabled)
+        if (Boolean.TRUE.equals(game.getUseFirstPickRule()) && nextPick.round == 1) {
              String pref = participant.getPreferredTeam();
              if (pref != null) {
                  String prefLower = pref.trim().toLowerCase();

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -70,10 +70,20 @@ public class FantasyDraftService {
     }
 
     @Transactional(readOnly = true)
-    public List<FantasyPlayerDto> getAvailablePlayers(Long gameSeq, String team, String position, String search, String sort) {
+    public List<FantasyPlayerDto> getAvailablePlayers(Long gameSeq, String team, String position, String search, String sort, String foreignerType) {
         if (team != null && team.isEmpty()) team = null;
         if (position != null && position.isEmpty()) position = null;
         if (search != null && search.isEmpty()) search = null;
+        if (foreignerType != null && foreignerType.isEmpty()) foreignerType = null;
+
+        FantasyPlayer.ForeignerType fType = null;
+        if (foreignerType != null) {
+            try {
+                fType = FantasyPlayer.ForeignerType.valueOf(foreignerType);
+            } catch (IllegalArgumentException e) {
+                // Invalid enum value, ignore or treat as null
+            }
+        }
 
         // 1. Get all picks for this game
         Set<Long> pickedPlayerSeqs;
@@ -87,7 +97,7 @@ public class FantasyDraftService {
         }
 
         // 2. Get filtered players from DB
-        List<FantasyPlayer> filteredPlayers = fantasyPlayerRepository.findPlayers(team, position, search);
+        List<FantasyPlayer> filteredPlayers = fantasyPlayerRepository.findPlayers(team, position, search, fType);
 
         // Sort
         if (sort != null) {

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -262,6 +262,7 @@ public class FantasyGameService {
 
             List<DraftPick> picks = picksByPart.getOrDefault(p.getPlayerId(), Collections.emptyList());
             List<FantasyPlayer> roster = picks.stream()
+                    .filter(pick -> pick.getAssignedPosition() != null && !"BENCH".equalsIgnoreCase(pick.getAssignedPosition()))
                     .map(pick -> players.get(pick.getFantasyPlayerSeq()))
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());

--- a/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
+++ b/src/main/java/com/sayai/record/fantasy/service/rules/Rule1Validator.java
@@ -89,7 +89,7 @@ public class Rule1Validator implements DraftRuleValidator {
         }
     }
 
-    private void validateTeamRestriction(List<FantasyPlayer> team) {
+    protected void validateTeamRestriction(List<FantasyPlayer> team) {
         Set<String> distinctTeams = team.stream()
                 .map(FantasyPlayer::getTeam)
                 .filter(Objects::nonNull)
@@ -142,7 +142,7 @@ public class Rule1Validator implements DraftRuleValidator {
         }
     }
 
-    private void validateForeignerLimits(List<FantasyPlayer> team) {
+    protected void validateForeignerLimits(List<FantasyPlayer> team) {
         long type1Count = team.stream().filter(p -> {
             FantasyPlayer.ForeignerType type = Optional.ofNullable(p.getForeignerType()).orElse(FantasyPlayer.ForeignerType.NONE);
             return type == FantasyPlayer.ForeignerType.TYPE_1;
@@ -161,12 +161,12 @@ public class Rule1Validator implements DraftRuleValidator {
         }
     }
 
-    private boolean canFit(List<FantasyPlayer> team) {
+    protected boolean canFit(List<FantasyPlayer> team) {
         Map<String, Integer> slots = new HashMap<>(getRequiredSlots());
         return backtrack(team, 0, slots);
     }
 
-    private boolean backtrack(List<FantasyPlayer> team, int index, Map<String, Integer> slots) {
+    protected boolean backtrack(List<FantasyPlayer> team, int index, Map<String, Integer> slots) {
         if (index == team.size()) {
             return true;
         }
@@ -192,10 +192,10 @@ public class Rule1Validator implements DraftRuleValidator {
         return false;
     }
 
-    private List<String> parsePositions(String positionString) {
-        if (positionString == null || positionString.isEmpty()) return Collections.emptyList();
+    protected List<String> parsePositions(String positionString) {
+        if (positionString == null || positionString.isEmpty()) return new ArrayList<>();
         return Arrays.stream(positionString.split(","))
                 .map(String::trim)
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -188,14 +188,11 @@
                 }
             });
 
-            $('#filter-team, #filter-position, #filter-foreigner, #sort-order').change(function() {
-                // If foreigner filter changes, we might need to reload from server if we didn't fetch all
-                // But current implementation of loadAvailablePlayers fetches ALL.
-                // However, the prompt says "search condition is foreigner_type values".
-                // If the list is large, server side is better.
-                // Given the existing code fetches "allAvailablePlayers" (which implies ALL),
-                // we can filter locally. BUT if we want to use the server feature we just added:
+            $('#filter-foreigner').change(function() {
                 loadAvailablePlayers(true); // Force reload with new filter
+            });
+            $('#filter-team, #filter-position, #sort-order').change(function() {
+                renderPlayers(); // Local filter
             });
             $('#search-player').on('keyup', function(e) {
                 renderPlayers(); // Local search
@@ -224,6 +221,7 @@
                 gameState.ruleType = data.ruleType; // RULE_1 or RULE_2
                 gameState.round = data.roundNum;
                 gameState.salaryCap = data.salaryCap;
+                gameState.useFirstPickRule = data.useFirstPickRule;
 
                 // Determine My Info
                 const myPart = gameState.participants.find(p => String(p.participantId) === String(userId));
@@ -439,8 +437,8 @@
                 let disabled = !isMyTurn;
                 let btnText = "Draft";
 
-                // Rule 2 Check
-                if (isMyTurn && gameState.ruleType === 'RULE_2' && isRound1) {
+                // First Pick Rule Check (applies to both Rule 1 and Rule 2)
+                if (isMyTurn && gameState.useFirstPickRule === true && isRound1) {
                      // Check team
                      const myTeam = (gameState.myPreferredTeam || "").toLowerCase().trim();
                      const pTeam = (player.team || "").toLowerCase().trim();
@@ -449,13 +447,6 @@
                          btnText = "Restricted"; // Or just keep disabled
                      }
                 }
-
-                // First Pick Rule (Rule 1 Option) Check
-                // We need to know if Rule 1 Option is enabled.
-                // Currently gameState doesn't explicitly store useFirstPickRule flag but backend sends RuleType.
-                // Assuming useFirstPickRule is property of game, we should fetch it in initGame.
-                // But for now, let's skip strict client-side check if we lack the flag, server will block.
-                // Or user can add the flag to initGame details.
 
                 // Salary Cap Check
                 if (isMyTurn && gameState.salaryCap && gameState.salaryCap > 0) {

--- a/src/main/resources/templates/fantasy/draft.html
+++ b/src/main/resources/templates/fantasy/draft.html
@@ -104,6 +104,12 @@
                         <option value="RP">RP</option>
                         <option value="CL">CL</option>
                     </select>
+                    <select id="filter-foreigner" style="padding: 5px;">
+                        <option value="">전체</option>
+                        <option value="TYPE_1">외국인</option>
+                        <option value="TYPE_2">아시아쿼터</option>
+                        <option value="NONE">토종</option>
+                    </select>
                     <select id="sort-order" style="padding: 5px;">
                         <option value="">기본 정렬</option>
                         <option value="cost_desc">Cost (High-Low)</option>
@@ -182,8 +188,14 @@
                 }
             });
 
-            $('#filter-team, #filter-position, #sort-order').change(function() {
-                renderPlayers(); // Local filter
+            $('#filter-team, #filter-position, #filter-foreigner, #sort-order').change(function() {
+                // If foreigner filter changes, we might need to reload from server if we didn't fetch all
+                // But current implementation of loadAvailablePlayers fetches ALL.
+                // However, the prompt says "search condition is foreigner_type values".
+                // If the list is large, server side is better.
+                // Given the existing code fetches "allAvailablePlayers" (which implies ALL),
+                // we can filter locally. BUT if we want to use the server feature we just added:
+                loadAvailablePlayers(true); // Force reload with new filter
             });
             $('#search-player').on('keyup', function(e) {
                 renderPlayers(); // Local search
@@ -359,13 +371,16 @@
 
         // Fetch all players once (or force refresh)
         function loadAvailablePlayers(force = false) {
-            if (isPlayersLoaded && !force) {
-                renderPlayers();
-                return;
-            }
+            // Because we added server-side filtering for ForeignerType,
+            // we should include it in the request.
+            // If we filter by ForeignerType on server, 'allAvailablePlayers' will only contain that subset.
+            // This changes the semantics of 'allAvailablePlayers' to 'currentFetchedPlayers'.
 
-            // Fetch ALL players (no server-side filters)
-            $.get(`/apis/v1/fantasy/games/${gameSeq}/available-players`, function(data) {
+            const foreignerType = $('#filter-foreigner').val();
+
+            $.get(`/apis/v1/fantasy/games/${gameSeq}/available-players`, {
+                foreignerType: foreignerType
+            }, function(data) {
                 allAvailablePlayers = data;
                 isPlayersLoaded = true;
                 renderPlayers();

--- a/src/main/resources/templates/fantasy/players.html
+++ b/src/main/resources/templates/fantasy/players.html
@@ -55,6 +55,12 @@
                     <option value="RF">RF</option>
                     <option value="DH">DH</option>
                 </select>
+                <select id="foreignerFilter" class="form-control" style="padding: 8px; width: 120px;">
+                    <option value="">전체</option>
+                    <option value="TYPE_1">외국인</option>
+                    <option value="TYPE_2">아시아쿼터</option>
+                    <option value="NONE">토종</option>
+                </select>
                 <input type="text" id="searchInput" placeholder="Search Player" class="form-control" style="padding: 8px; width: 150px;">
                 <select id="sortOrder" class="form-control" style="padding: 8px; width: 150px;">
                     <option value="cost_desc">Cost High-Low</option>
@@ -218,12 +224,14 @@
             const pos = $('#posFilter').val();
             const search = $('#searchInput').val();
             const sort = $('#sortOrder').val();
+            const foreignerType = $('#foreignerFilter').val();
 
             $.get(`/apis/v1/fantasy/games/0/available-players`, {
                 team: team,
                 position: pos,
                 search: search,
-                sort: sort
+                sort: sort,
+                foreignerType: foreignerType
             }, function(players) {
                 const tbody = $('#playerListBody');
                 tbody.empty();

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceAutoPickTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceAutoPickTest.java
@@ -1,0 +1,109 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.entity.*;
+import com.sayai.record.fantasy.repository.DraftPickRepository;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
+import com.sayai.record.fantasy.repository.FantasyPlayerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class FantasyDraftServiceAutoPickTest {
+
+    @Mock
+    private FantasyGameRepository fantasyGameRepository;
+    @Mock
+    private FantasyPlayerRepository fantasyPlayerRepository;
+    @Mock
+    private FantasyParticipantRepository fantasyParticipantRepository;
+    @Mock
+    private DraftPickRepository draftPickRepository;
+    @Mock
+    private DraftValidator draftValidator;
+    @Mock
+    private org.springframework.messaging.simp.SimpMessagingTemplate messagingTemplate;
+    @Mock
+    private org.springframework.beans.factory.ObjectProvider<DraftScheduler> draftSchedulerProvider;
+
+    @InjectMocks
+    private FantasyDraftService fantasyDraftService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testAutoPick_FirstPickRule_Disabled() {
+        // Arrange
+        Long gameSeq = 1L;
+        Long playerId = 100L;
+
+        FantasyGame game = FantasyGame.builder()
+                .seq(gameSeq)
+                .status(FantasyGame.GameStatus.DRAFTING)
+                .ruleType(FantasyGame.RuleType.RULE_2)
+                .useFirstPickRule(false) // Disabled!
+                .build();
+
+        // Mock game finding
+        when(fantasyGameRepository.findById(gameSeq)).thenReturn(Optional.of(game));
+
+        // Mock Picks (empty -> Round 1)
+        when(draftPickRepository.countByFantasyGameSeq(gameSeq)).thenReturn(0L);
+        when(draftPickRepository.findByFantasyGameSeq(gameSeq)).thenReturn(Collections.emptyList());
+
+        // Mock Participants
+        FantasyParticipant p = FantasyParticipant.builder()
+                .playerId(playerId)
+                .draftOrder(1)
+                .preferredTeam("KIA")
+                .build();
+        when(fantasyParticipantRepository.findByFantasyGameSeq(gameSeq)).thenReturn(Collections.singletonList(p));
+        when(fantasyParticipantRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId)).thenReturn(Optional.of(p));
+
+        // Mock Players
+        // P1: Samsung (Should be picked if rule disabled, but not if enabled and pref is KIA)
+        FantasyPlayer p1 = FantasyPlayer.builder().seq(1L).name("P1").team("Samsung").cost(10).position("C").build();
+        // P2: KIA
+        FantasyPlayer p2 = FantasyPlayer.builder().seq(2L).name("P2").team("KIA").cost(10).position("C").build();
+
+        List<FantasyPlayer> available = new ArrayList<>();
+        available.add(p1);
+        // We only add p1 to test if it CAN be picked.
+        // If logic was restrictive, candidates would be empty (filtered out p1).
+
+        when(fantasyPlayerRepository.findAll()).thenReturn(available);
+        when(fantasyPlayerRepository.findById(1L)).thenReturn(Optional.of(p1));
+
+        // Validator should pass for any player since we mock it
+        doNothing().when(draftValidator).validate(any(), any(), any(), any());
+
+        // Mock getTotalPlayerCount - required by draftPlayer logic to check if finished
+        when(draftValidator.getTotalPlayerCount(any())).thenReturn(20);
+
+        // Mock DraftPickRepository.exists to return false (not picked yet)
+        when(draftPickRepository.existsByFantasyGameSeqAndFantasyPlayerSeq(anyLong(), anyLong())).thenReturn(false);
+        // Mock User Picks in draftPlayer
+        when(draftPickRepository.findByFantasyGameSeqAndPlayerId(anyLong(), anyLong())).thenReturn(Collections.emptyList());
+
+        // Act
+        fantasyDraftService.autoPick(gameSeq);
+
+        // Assert
+        // Should draft P1 because rule is disabled, so candidates list wasn't filtered by team
+        verify(draftPickRepository, times(1)).save(any(DraftPick.class));
+    }
+}

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceFilterTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceFilterTest.java
@@ -38,9 +38,9 @@ class FantasyDraftServiceFilterTest {
         FantasyPlayer p1 = FantasyPlayer.builder().seq(1L).name("Kim").team("Doosan").position("P").cost(10).build();
 
         when(draftPickRepository.findByFantasyGameSeq(gameSeq)).thenReturn(Collections.emptyList());
-        when(fantasyPlayerRepository.findPlayers(team, pos, search)).thenReturn(Collections.singletonList(p1));
+        when(fantasyPlayerRepository.findPlayers(team, pos, search, null)).thenReturn(Collections.singletonList(p1));
 
-        List<FantasyPlayerDto> result = fantasyDraftService.getAvailablePlayers(gameSeq, team, pos, search, null);
+        List<FantasyPlayerDto> result = fantasyDraftService.getAvailablePlayers(gameSeq, team, pos, search, null, null);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getName()).isEqualTo("Kim");
@@ -54,10 +54,10 @@ class FantasyDraftServiceFilterTest {
         String search = "";
 
         // Expect findPlayers to be called with nulls
-        when(fantasyPlayerRepository.findPlayers(null, null, null)).thenReturn(Collections.emptyList());
+        when(fantasyPlayerRepository.findPlayers(null, null, null, null)).thenReturn(Collections.emptyList());
 
-        fantasyDraftService.getAvailablePlayers(gameSeq, team, pos, search, null);
+        fantasyDraftService.getAvailablePlayers(gameSeq, team, pos, search, null, null);
 
-        verify(fantasyPlayerRepository).findPlayers(null, null, null);
+        verify(fantasyPlayerRepository).findPlayers(null, null, null, null);
     }
 }

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyDraftServiceTest.java
@@ -1,0 +1,68 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.dto.FantasyPlayerDto;
+import com.sayai.record.fantasy.entity.FantasyPlayer;
+import com.sayai.record.fantasy.repository.DraftPickRepository;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
+import com.sayai.record.fantasy.repository.FantasyPlayerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+class FantasyDraftServiceTest {
+
+    @Mock private FantasyPlayerRepository fantasyPlayerRepository;
+    @Mock private DraftPickRepository draftPickRepository;
+    @Mock private FantasyGameRepository fantasyGameRepository;
+    @Mock private FantasyParticipantRepository fantasyParticipantRepository;
+    @Mock private DraftValidator draftValidator;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private FantasyDraftService fantasyDraftService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAvailablePlayers_ForeignerType() {
+        // Arrange
+        FantasyPlayer p1 = FantasyPlayer.builder().seq(1L).name("P1").foreignerType(FantasyPlayer.ForeignerType.TYPE_1).cost(10).build();
+        FantasyPlayer p2 = FantasyPlayer.builder().seq(2L).name("P2").foreignerType(FantasyPlayer.ForeignerType.NONE).cost(10).build();
+
+        // When filtering by TYPE_1, repository returns p1
+        when(fantasyPlayerRepository.findPlayers(isNull(), isNull(), isNull(), eq(FantasyPlayer.ForeignerType.TYPE_1)))
+                .thenReturn(Collections.singletonList(p1));
+
+        // When filtering by NONE, repository returns p2
+        when(fantasyPlayerRepository.findPlayers(isNull(), isNull(), isNull(), eq(FantasyPlayer.ForeignerType.NONE)))
+                .thenReturn(Collections.singletonList(p2));
+
+        // Mock DraftPicks (empty)
+        when(draftPickRepository.findByFantasyGameSeq(anyLong())).thenReturn(Collections.emptyList());
+
+        // Act & Assert 1
+        List<FantasyPlayerDto> result1 = fantasyDraftService.getAvailablePlayers(1L, null, null, null, null, "TYPE_1");
+        assertEquals(1, result1.size());
+        assertEquals("P1", result1.get(0).getName());
+
+        // Act & Assert 2
+        List<FantasyPlayerDto> result2 = fantasyDraftService.getAvailablePlayers(1L, null, null, null, null, "NONE");
+        assertEquals(1, result2.size());
+        assertEquals("P2", result2.get(0).getName());
+    }
+}

--- a/src/test/java/com/sayai/record/fantasy/service/rules/Rule2ValidatorTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/rules/Rule2ValidatorTest.java
@@ -1,0 +1,129 @@
+package com.sayai.record.fantasy.service.rules;
+
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.entity.FantasyParticipant;
+import com.sayai.record.fantasy.entity.FantasyPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Rule2ValidatorTest {
+
+    private Rule2Validator validator;
+    private FantasyGame game;
+    private FantasyParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        validator = new Rule2Validator();
+        game = FantasyGame.builder()
+                .ruleType(FantasyGame.RuleType.RULE_2)
+                .useFirstPickRule(false) // Default disabled
+                .build();
+        participant = FantasyParticipant.builder()
+                .preferredTeam("KIA")
+                .build();
+    }
+
+    @Test
+    void testTotalPlayerCount() {
+        assertEquals(20, validator.getTotalPlayerCount());
+    }
+
+    @Test
+    void testFirstPickRule_Success() {
+        // Enable Rule
+        game.setUseFirstPickRule(true);
+        FantasyPlayer p = FantasyPlayer.builder().team("KIA Tigers").position("C").cost(10).build();
+        assertDoesNotThrow(() -> validator.validate(game, p, Collections.emptyList(), participant));
+    }
+
+    @Test
+    void testFirstPickRule_Fail() {
+        // Enable Rule
+        game.setUseFirstPickRule(true);
+        FantasyPlayer p = FantasyPlayer.builder().team("Samsung Lions").position("C").cost(10).build();
+        assertThrows(IllegalStateException.class, () -> validator.validate(game, p, Collections.emptyList(), participant));
+    }
+
+    @Test
+    void testFirstPickRule_Disabled() {
+        // Disable Rule (default)
+        game.setUseFirstPickRule(false);
+        FantasyPlayer p = FantasyPlayer.builder().team("Samsung Lions").position("C").cost(10).build();
+        assertDoesNotThrow(() -> validator.validate(game, p, Collections.emptyList(), participant));
+    }
+
+    @Test
+    void testValidComposition() {
+        // Create 18 mandatory players
+        List<FantasyPlayer> team = new ArrayList<>();
+        team.add(createPlayer("C", "C"));
+        team.add(createPlayer("1B", "1B"));
+        team.add(createPlayer("2B", "2B"));
+        team.add(createPlayer("3B", "3B"));
+        team.add(createPlayer("SS", "SS"));
+        team.add(createPlayer("LF", "LF"));
+        team.add(createPlayer("CF", "CF"));
+        team.add(createPlayer("RF", "RF"));
+        team.add(createPlayer("DH", "DH"));
+
+        // 4 SP, 4 RP, 1 CL
+        for(int i=0; i<4; i++) team.add(createPlayer("SP", "SP"));
+        for(int i=0; i<4; i++) team.add(createPlayer("RP", "RP"));
+        team.add(createPlayer("CL", "CL"));
+
+        // 18 players so far.
+        // Add 1 extra player (Bench)
+        team.add(createPlayer("ExtraC", "C"));
+
+        // Add last player (Bench)
+        FantasyPlayer last = createPlayer("ExtraSP", "SP");
+
+        assertDoesNotThrow(() -> validator.validate(game, last, team, participant));
+    }
+
+    @Test
+    void testInvalidComposition_MissingMandatory() {
+        // 19 players, but missing 1B (replaced by something else)
+        List<FantasyPlayer> team = new ArrayList<>();
+        team.add(createPlayer("C", "C"));
+        // No 1B
+        team.add(createPlayer("2B", "2B")); // Extra 2B
+        team.add(createPlayer("2B", "2B"));
+        team.add(createPlayer("3B", "3B"));
+        team.add(createPlayer("SS", "SS"));
+        team.add(createPlayer("LF", "LF"));
+        team.add(createPlayer("CF", "CF"));
+        team.add(createPlayer("RF", "RF"));
+        team.add(createPlayer("DH", "DH"));
+
+        for(int i=0; i<4; i++) team.add(createPlayer("SP", "SP"));
+        for(int i=0; i<4; i++) team.add(createPlayer("RP", "RP"));
+        team.add(createPlayer("CL", "CL"));
+
+        // Add bench to reach 19
+        team.add(createPlayer("Bench1", "C"));
+        team.add(createPlayer("Bench2", "C"));
+
+        // Try adding a non-1B player as 20th.
+        FantasyPlayer p = createPlayer("Not1B", "C");
+
+        // Should fail because even with 20 players, we haven't filled 1B slot.
+        assertThrows(IllegalStateException.class, () -> validator.validate(game, p, team, participant));
+    }
+
+    private FantasyPlayer createPlayer(String name, String pos) {
+        return FantasyPlayer.builder()
+                .name(name)
+                .position(pos)
+                .team("KIA") // Match preferred
+                .cost(10)
+                .build();
+    }
+}


### PR DESCRIPTION
Implemented Rule 2 Validator with 20-player roster requirement (18 active + 2 bench) and updated roster export to exclude bench players. Refactored Rule 2 Validator to inherit common validation logic from Rule 1. Fixed potential runtime exception in position parsing. Added comprehensive unit tests.

---
*PR created automatically by Jules for task [2995063153245950311](https://jules.google.com/task/2995063153245950311) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a foreigner-type filter to the Available Players UI and extended the API/service to accept this filter; client reloads when it changes. First-pick rule handling made more generally configurable.

* **Bug Fixes**
  * Roster export now excludes bench and unassigned players.

* **Validation**
  * Enhanced lineup validation: stricter team-coverage checks, refined position/backtracking feasibility, and adjusted foreigner-limit handling.

* **Tests**
  * Added and updated tests for foreigner filtering, roster export, auto-pick, and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->