### PR TITLE
Filter trade.html game list to show only ONGOING games

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
@@ -40,7 +40,7 @@ public class FantasyGameController {
 
     @GetMapping("/my-games")
     public ResponseEntity<List<FantasyGameDto>> getMyGames(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                           @RequestParam(required = false) FantasyGame.GameStatus status) {
+                                                           @RequestParam(name = "status", required = false) FantasyGame.GameStatus status) {
         if (userDetails == null) {
             return ResponseEntity.status(401).build();
         }

--- a/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
+++ b/src/main/java/com/sayai/record/fantasy/controller/FantasyGameController.java
@@ -6,6 +6,7 @@ import com.sayai.record.auth.repository.MemberRepository;
 import com.sayai.record.fantasy.dto.DraftLogDto;
 import com.sayai.record.fantasy.dto.FantasyGameDetailDto;
 import com.sayai.record.fantasy.dto.FantasyGameDto;
+import com.sayai.record.fantasy.entity.FantasyGame;
 import com.sayai.record.fantasy.entity.FantasyParticipant;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import com.sayai.record.fantasy.service.FantasyGameService;
@@ -38,11 +39,12 @@ public class FantasyGameController {
     }
 
     @GetMapping("/my-games")
-    public ResponseEntity<List<FantasyGameDto>> getMyGames(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<List<FantasyGameDto>> getMyGames(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                           @RequestParam(required = false) FantasyGame.GameStatus status) {
         if (userDetails == null) {
             return ResponseEntity.status(401).build();
         }
-        return ResponseEntity.ok(fantasyGameService.getMyGames(userDetails.getPlayerId()));
+        return ResponseEntity.ok(fantasyGameService.getMyGames(userDetails.getPlayerId(), status));
     }
 
 

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -68,7 +68,7 @@ public class FantasyGameService {
     }
 
     @Transactional(readOnly = true)
-    public List<FantasyGameDto> getMyGames(Long userId) {
+    public List<FantasyGameDto> getMyGames(Long userId, FantasyGame.GameStatus status) {
         // Find games where user participated
         List<FantasyParticipant> myParticipations = fantasyParticipantRepository.findAll().stream()
                 .filter(p -> p.getPlayerId().equals(userId))
@@ -79,6 +79,10 @@ public class FantasyGameService {
                 .collect(Collectors.toList());
 
         List<FantasyGame> games = fantasyGameRepository.findAllById(gameSeqs);
+
+        if (status != null) {
+            games = games.stream().filter(g -> g.getStatus() == status).collect(Collectors.toList());
+        }
 
         return games.stream().map(FantasyGameDto::from).collect(Collectors.toList());
     }

--- a/src/main/resources/templates/fantasy/trade.html
+++ b/src/main/resources/templates/fantasy/trade.html
@@ -234,7 +234,7 @@
 
         function loadMyGames() {
             // Passing userId just in case backend requires it, but AuthPrincipal usually handles it
-            $.get('/apis/v1/fantasy/my-games', function(games) {
+            $.get('/apis/v1/fantasy/my-games?status=ONGOING', function(games) {
                 const select = $('#gameSelector');
                 select.empty();
                 if (games.length === 0) {

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceMyGamesTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceMyGamesTest.java
@@ -1,0 +1,80 @@
+package com.sayai.record.fantasy.service;
+
+import com.sayai.record.fantasy.dto.FantasyGameDto;
+import com.sayai.record.fantasy.entity.FantasyGame;
+import com.sayai.record.fantasy.entity.FantasyParticipant;
+import com.sayai.record.fantasy.repository.DraftPickRepository;
+import com.sayai.record.fantasy.repository.FantasyGameRepository;
+import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
+import com.sayai.record.fantasy.repository.FantasyPlayerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class FantasyGameServiceMyGamesTest {
+
+    @Mock private FantasyGameRepository fantasyGameRepository;
+    @Mock private FantasyParticipantRepository fantasyParticipantRepository;
+    @Mock private DraftPickRepository draftPickRepository;
+    @Mock private FantasyPlayerRepository fantasyPlayerRepository;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private FantasyDraftService fantasyDraftService;
+    @Mock private DraftScheduler draftScheduler;
+
+    @InjectMocks
+    private FantasyGameService fantasyGameService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetMyGames_NoFilter() {
+        Long userId = 100L;
+        Long gameSeq1 = 1L;
+        Long gameSeq2 = 2L;
+
+        FantasyParticipant p1 = FantasyParticipant.builder().fantasyGameSeq(gameSeq1).playerId(userId).build();
+        FantasyParticipant p2 = FantasyParticipant.builder().fantasyGameSeq(gameSeq2).playerId(userId).build();
+        when(fantasyParticipantRepository.findAll()).thenReturn(Arrays.asList(p1, p2));
+
+        FantasyGame g1 = FantasyGame.builder().seq(gameSeq1).status(FantasyGame.GameStatus.ONGOING).title("Game1").build();
+        FantasyGame g2 = FantasyGame.builder().seq(gameSeq2).status(FantasyGame.GameStatus.FINISHED).title("Game2").build();
+        when(fantasyGameRepository.findAllById(Arrays.asList(gameSeq1, gameSeq2))).thenReturn(Arrays.asList(g1, g2));
+
+        List<FantasyGameDto> result = fantasyGameService.getMyGames(userId, null);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testGetMyGames_WithFilter() {
+        Long userId = 100L;
+        Long gameSeq1 = 1L;
+        Long gameSeq2 = 2L;
+
+        FantasyParticipant p1 = FantasyParticipant.builder().fantasyGameSeq(gameSeq1).playerId(userId).build();
+        FantasyParticipant p2 = FantasyParticipant.builder().fantasyGameSeq(gameSeq2).playerId(userId).build();
+        when(fantasyParticipantRepository.findAll()).thenReturn(Arrays.asList(p1, p2));
+
+        FantasyGame g1 = FantasyGame.builder().seq(gameSeq1).status(FantasyGame.GameStatus.ONGOING).title("Game1").build();
+        FantasyGame g2 = FantasyGame.builder().seq(gameSeq2).status(FantasyGame.GameStatus.FINISHED).title("Game2").build();
+        when(fantasyGameRepository.findAllById(Arrays.asList(gameSeq1, gameSeq2))).thenReturn(Arrays.asList(g1, g2));
+
+        List<FantasyGameDto> result = fantasyGameService.getMyGames(userId, FantasyGame.GameStatus.ONGOING);
+
+        assertEquals(1, result.size());
+        assertEquals(FantasyGame.GameStatus.ONGOING, result.get(0).getStatus());
+        assertEquals("Game1", result.get(0).getTitle());
+    }
+}


### PR DESCRIPTION
This PR modifies the `trade.html` page to only display games with `ONGOING` status, preventing users from attempting trades in finished or pre-draft games. It introduces an optional `status` parameter to the `getMyGames` API endpoint and service method to support this filtering. A new unit test is added to verify the backend logic.

---
*PR created automatically by Jules for task [16887351573918734701](https://jules.google.com/task/16887351573918734701) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional status-based filtering when listing your fantasy games.
  * Trade view now fetches only ongoing games by default.

* **Tests**
  * Added unit tests verifying game list behavior with and without status filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->