### PR TITLE
feat: Add team name length validation on join form

### DIFF
--- a/src/main/resources/templates/fantasy/index.html
+++ b/src/main/resources/templates/fantasy/index.html
@@ -154,10 +154,17 @@
 
             $('#joinForm').submit(function(e) {
                 e.preventDefault();
+
+                const teamName = $('#joinTeamName').val();
+                if (teamName.replace(/\s/g, '').length < 5) {
+                    alert('팀명은 공백을 제외하고 5자 이상이어야 합니다.');
+                    return false;
+                }
+
                 const seq = $('#joinGameSeq').val();
                 const data = {
                     preferredTeam: $('#joinPrefTeam').val(),
-                    teamName: $('#joinTeamName').val()
+                    teamName: teamName
                 };
 
                 $.ajax({


### PR DESCRIPTION
This PR adds a client-side validation logic inside `src/main/resources/templates/fantasy/index.html` to prevent users from submitting a team name shorter than 5 characters (excluding spaces) when joining a fantasy league.

### Changes
* Intercepts `#joinForm` submit event.
* Validates `teamName` input length after stripping spaces (`/\s/g`).
* Triggers a javascript `alert` and halts submission via `return false;` if the validation fails.

---
*PR created automatically by Jules for task [4911291309472875065](https://jules.google.com/task/4911291309472875065) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added form validation for team name submission, requiring a minimum of 5 characters (excluding whitespace). Invalid submissions now display an error message and prevent submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->