### PR TITLE
Implement Draft Pick Snapshot for KBO Stats

### DIFF
--- a/src/main/java/com/sayai/kbo/service/FantasyKboService.java
+++ b/src/main/java/com/sayai/kbo/service/FantasyKboService.java
@@ -4,9 +4,9 @@ import com.sayai.kbo.dto.ParticipantKboStatsDto;
 import com.sayai.kbo.repository.KboHitRepository;
 import com.sayai.kbo.repository.KboParticipantStatsInterface;
 import com.sayai.kbo.repository.KboPitchRepository;
-import com.sayai.record.fantasy.entity.DraftPick;
 import com.sayai.record.fantasy.entity.FantasyParticipant;
-import com.sayai.record.fantasy.repository.DraftPickRepository;
+import com.sayai.record.fantasy.entity.DraftPickSnapshot;
+import com.sayai.record.fantasy.repository.DraftPickSnapshotRepository;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 public class FantasyKboService {
 
     private final FantasyParticipantRepository participantRepository;
-    private final DraftPickRepository draftPickRepository;
+    private final DraftPickSnapshotRepository draftPickSnapshotRepository;
     private final KboHitRepository kboHitRepository;
     private final KboPitchRepository kboPitchRepository;
 
@@ -45,16 +45,13 @@ public class FantasyKboService {
             return Collections.emptyList();
         }
 
-        List<DraftPick> draftPicks = draftPickRepository.findByFantasyGameSeq(gameSeq);
-        // Filter only active/normal picks (or whatever criteria means they "own" the player during this period)
-        // If they need to hold them, pickStatus.NORMAL might be the way, but since we just aggregate, we map all valid ones.
-        // The prompt says "participants 들의 draft_pick 조회" so we map participant -> list of playerIds.
+        List<DraftPickSnapshot> draftPicks = draftPickSnapshotRepository.findByFantasyGameSeq(gameSeq);
 
         Map<Long, List<Long>> participantToPlayerIds = new HashMap<>();
         Map<Long, Long> playerToParticipantId = new HashMap<>();
 
-        for (DraftPick pick : draftPicks) {
-            if (pick.getPickStatus() != DraftPick.PickStatus.NORMAL && pick.getPickStatus() != DraftPick.PickStatus.TRADE_PENDING) {
+        for (DraftPickSnapshot pick : draftPicks) {
+            if (pick.getPickStatus() != DraftPickSnapshot.PickStatus.NORMAL && pick.getPickStatus() != DraftPickSnapshot.PickStatus.TRADE_PENDING) {
                 // If waiver req or other non-roster status, decide whether to include.
                 // Usually NORMAL implies they are on the roster.
                 // Assuming we just include them if they have a draft pick record. Let's include NORMAL.

--- a/src/main/java/com/sayai/record/fantasy/entity/DraftPickSnapshot.java
+++ b/src/main/java/com/sayai/record/fantasy/entity/DraftPickSnapshot.java
@@ -1,0 +1,57 @@
+package com.sayai.record.fantasy.entity;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "ft_draft_picks_snapshat")
+@Entity
+public class DraftPickSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    private Long playerId;
+
+    @Column(name = "fantasy_player_seq")
+    private Long fantasyPlayerSeq;
+
+    @Column(name = "fantasy_game_seq")
+    private Long fantasyGameSeq;
+
+    @Column(name = "pick_number")
+    private Integer pickNumber;
+
+    private String assignedPosition;
+
+    private LocalDateTime pickedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20) DEFAULT 'NORMAL'")
+    @Builder.Default
+    private PickStatus pickStatus = PickStatus.NORMAL;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.pickedAt == null) {
+            this.pickedAt = LocalDateTime.now(ZoneId.of("UTC"));
+        }
+        if (this.pickStatus == null) {
+            this.pickStatus = PickStatus.NORMAL;
+        }
+    }
+
+    public enum PickStatus {
+        NORMAL,
+        WAIVER_REQ,
+        TRADE_PENDING
+    }
+}

--- a/src/main/java/com/sayai/record/fantasy/repository/DraftPickSnapshotRepository.java
+++ b/src/main/java/com/sayai/record/fantasy/repository/DraftPickSnapshotRepository.java
@@ -1,0 +1,14 @@
+package com.sayai.record.fantasy.repository;
+
+import com.sayai.record.fantasy.entity.DraftPickSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface DraftPickSnapshotRepository extends JpaRepository<DraftPickSnapshot, Long> {
+    List<DraftPickSnapshot> findByFantasyGameSeq(Long fantasyGameSeq);
+
+    @Transactional
+    void deleteByFantasyGameSeq(Long fantasyGameSeq);
+}

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyGameService.java
@@ -4,8 +4,10 @@ import com.sayai.record.fantasy.dto.*;
 import com.sayai.record.fantasy.entity.DraftPick;
 import com.sayai.record.fantasy.entity.FantasyGame;
 import com.sayai.record.fantasy.entity.FantasyParticipant;
+import com.sayai.record.fantasy.entity.DraftPickSnapshot;
 import com.sayai.record.fantasy.entity.FantasyPlayer;
 import com.sayai.record.fantasy.repository.DraftPickRepository;
+import com.sayai.record.fantasy.repository.DraftPickSnapshotRepository;
 import com.sayai.record.fantasy.repository.FantasyGameRepository;
 import com.sayai.record.fantasy.repository.FantasyParticipantRepository;
 import com.sayai.record.fantasy.repository.FantasyPlayerRepository;
@@ -29,6 +31,7 @@ public class FantasyGameService {
     private final FantasyGameRepository fantasyGameRepository;
     private final FantasyParticipantRepository fantasyParticipantRepository;
     private final DraftPickRepository draftPickRepository;
+    private final DraftPickSnapshotRepository draftPickSnapshotRepository;
     private final FantasyPlayerRepository fantasyPlayerRepository;
     private final SimpMessagingTemplate messagingTemplate;
     private final FantasyDraftService fantasyDraftService;
@@ -234,7 +237,7 @@ public class FantasyGameService {
         }
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public String exportRoster(Long gameSeq) {
         FantasyGame game = fantasyGameRepository.findById(gameSeq)
                 .orElseThrow(() -> new IllegalArgumentException("Game not found"));
@@ -245,6 +248,8 @@ public class FantasyGameService {
             // Or just return empty or proceed. Requirement says "ONGOING".
         }
 
+        draftPickSnapshotRepository.deleteByFantasyGameSeq(gameSeq);
+
         List<FantasyParticipant> participants = fantasyParticipantRepository.findByFantasyGameSeq(gameSeq);
         List<DraftPick> allPicks = draftPickRepository.findByFantasyGameSeq(gameSeq);
 
@@ -253,6 +258,8 @@ public class FantasyGameService {
                 .collect(Collectors.toMap(FantasyPlayer::getSeq, Function.identity()));
 
         Map<Long, List<DraftPick>> picksByPart = allPicks.stream().collect(Collectors.groupingBy(DraftPick::getPlayerId));
+
+        List<DraftPickSnapshot> snapshotsToSave = new ArrayList<>();
 
         // Prepare data grid: Participant -> { Batters, Pitchers }
         List<List<String>> allBatters = new ArrayList<>();
@@ -263,8 +270,24 @@ public class FantasyGameService {
             teamNames.add(p.getTeamName());
 
             List<DraftPick> picks = picksByPart.getOrDefault(p.getPlayerId(), Collections.emptyList());
-            List<FantasyPlayer> roster = picks.stream()
+            List<DraftPick> validPicks = picks.stream()
                     .filter(pick -> pick.getAssignedPosition() != null && !"BENCH".equalsIgnoreCase(pick.getAssignedPosition()))
+                    .collect(Collectors.toList());
+
+            for (DraftPick pick : validPicks) {
+                DraftPickSnapshot snapshot = DraftPickSnapshot.builder()
+                        .playerId(pick.getPlayerId())
+                        .fantasyPlayerSeq(pick.getFantasyPlayerSeq())
+                        .fantasyGameSeq(pick.getFantasyGameSeq())
+                        .pickNumber(pick.getPickNumber())
+                        .assignedPosition(pick.getAssignedPosition())
+                        .pickedAt(pick.getPickedAt())
+                        .pickStatus(DraftPickSnapshot.PickStatus.valueOf(pick.getPickStatus().name()))
+                        .build();
+                snapshotsToSave.add(snapshot);
+            }
+
+            List<FantasyPlayer> roster = validPicks.stream()
                     .map(pick -> players.get(pick.getFantasyPlayerSeq()))
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
@@ -320,6 +343,8 @@ public class FantasyGameService {
             }
             sb.append('\n');
         }
+
+        draftPickSnapshotRepository.saveAll(snapshotsToSave);
 
         return sb.toString();
     }

--- a/src/test/java/com/sayai/record/fantasy/controller/FantasyViewControllerTest.java
+++ b/src/test/java/com/sayai/record/fantasy/controller/FantasyViewControllerTest.java
@@ -5,7 +5,7 @@ import com.sayai.record.fantasy.service.FantasyGameService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,10 +18,10 @@ class FantasyViewControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private FantasyGameService fantasyGameService;
 
-    @MockBean
+    @MockitoBean
     private MemberRepository memberRepository;
 
     @Test

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServicePerformanceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServicePerformanceTest.java
@@ -30,6 +30,9 @@ class FantasyGameServicePerformanceTest {
     private DraftPickRepository draftPickRepository;
 
     @Mock
+    private com.sayai.record.fantasy.repository.DraftPickSnapshotRepository draftPickSnapshotRepository;
+
+    @Mock
     private FantasyPlayerRepository fantasyPlayerRepository;
 
     @Mock
@@ -50,6 +53,7 @@ class FantasyGameServicePerformanceTest {
                 fantasyGameRepository,
                 fantasyParticipantRepository,
                 draftPickRepository,
+                draftPickSnapshotRepository,
                 fantasyPlayerRepository,
                 messagingTemplate,
                 fantasyDraftService,

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceTest.java
@@ -29,6 +29,7 @@ class FantasyGameServiceTest {
     @Mock private FantasyGameRepository fantasyGameRepository;
     @Mock private FantasyParticipantRepository fantasyParticipantRepository;
     @Mock private DraftPickRepository draftPickRepository;
+    @Mock private com.sayai.record.fantasy.repository.DraftPickSnapshotRepository draftPickSnapshotRepository;
     @Mock private FantasyPlayerRepository fantasyPlayerRepository;
     @Mock private SimpMessagingTemplate messagingTemplate;
     @Mock private FantasyDraftService fantasyDraftService;


### PR DESCRIPTION
Implemented a snapshot mechanism for draft picks during roster export. This ensures that the `/apis/v1/fantasy/games/{gameSeq}/kbo-stats` API calculates statistics based on the static snapshot of participants' rosters (excluding bench players) rather than real-time draft picks.

---
*PR created automatically by Jules for task [14371328340329438197](https://jules.google.com/task/14371328340329438197) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Draft pick snapshots are now automatically captured and saved during roster export, enabling historical tracking of draft picks and their statuses.
  * Roster export now filters to display only active picks, excluding bench positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->