### PR TITLE
Increase authentication token validity to 6 hours

### DIFF
--- a/src/main/java/com/sayai/record/auth/controller/AuthController.java
+++ b/src/main/java/com/sayai/record/auth/controller/AuthController.java
@@ -32,7 +32,7 @@ public class AuthController {
                 .httpOnly(true)
                 .secure(false) // Set true in production (HTTPS)
                 .path("/")
-                .maxAge(3600) // 1 hour
+                .maxAge(21600) // 6 hours
                 .sameSite("Strict")
                 .build();
 

--- a/src/main/java/com/sayai/record/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sayai/record/auth/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private Key secretKey;
-    private final long tokenValidityInMilliseconds = 3600000; // 1h
+    private final long tokenValidityInMilliseconds = 21600000; // 6h
 
     @PostConstruct
     protected void init() {

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceDraftSchedulerTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServiceDraftSchedulerTest.java
@@ -21,6 +21,7 @@ class FantasyGameServiceDraftSchedulerTest {
 
     @Mock private FantasyGameRepository fantasyGameRepository;
     @Mock private FantasyParticipantRepository fantasyParticipantRepository;
+    @Mock private com.sayai.record.fantasy.repository.FantasyWaiverOrderRepository waiverOrderRepository;
     @Mock private DraftScheduler draftScheduler;
     @Mock private SimpMessagingTemplate messagingTemplate;
 

--- a/src/test/java/com/sayai/record/fantasy/service/FantasyGameServicePerformanceTest.java
+++ b/src/test/java/com/sayai/record/fantasy/service/FantasyGameServicePerformanceTest.java
@@ -55,6 +55,7 @@ class FantasyGameServicePerformanceTest {
                 draftPickRepository,
                 draftPickSnapshotRepository,
                 fantasyPlayerRepository,
+            org.mockito.Mockito.mock(com.sayai.record.fantasy.repository.FantasyWaiverOrderRepository.class),
                 messagingTemplate,
                 fantasyDraftService,
                 draftScheduler


### PR DESCRIPTION
Updates the JWT token validity in `JwtTokenProvider.java` and the corresponding cookie `maxAge` in `AuthController.java` to 6 hours (21600 seconds/21600000 milliseconds) as requested. Also includes minor fixes to mocking dependencies in test classes to ensure a clean build.

---
*PR created automatically by Jules for task [16324007948054159662](https://jules.google.com/task/16324007948054159662) started by @YeonDo*