### PR TITLE
Configure Gradle to include fcm-key.json from record-private submodule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,10 +64,15 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-task copyPrivate(type: Copy){
-	copy{
-		from './record-private/private'
-		include "*.yml"
-		into 'src/main/resources'
+task copyPrivate(type: Copy) {
+	from './record-private/private'
+	include "*.yml"
+	into 'src/main/resources'
+}
+
+processResources {
+	from('./record-private/private') {
+		include 'fcm-key.json'
+		into 'record-private'
 	}
 }

--- a/src/main/java/com/sayai/record/firebase/FirebaseConfig.java
+++ b/src/main/java/com/sayai/record/firebase/FirebaseConfig.java
@@ -6,28 +6,45 @@ import com.google.firebase.FirebaseOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 import jakarta.annotation.PostConstruct;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 
 @Slf4j
 @Configuration
 public class FirebaseConfig {
 
-    @Value("${firebase.key-path}")
+    @Value("${firebase.key-path:}")
     private String serviceAccountPath;
 
     @PostConstruct
     public void init() {
         try {
-            FirebaseOptions options;
+            FirebaseOptions options = null;
             if (serviceAccountPath != null && !serviceAccountPath.isEmpty()) {
-                FileInputStream serviceAccount = new FileInputStream(serviceAccountPath);
-                options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                        .build();
-            } else {
+                InputStream serviceAccount = null;
+                try {
+                    serviceAccount = new ClassPathResource(serviceAccountPath).getInputStream();
+                } catch (IOException e) {
+                    log.warn("Could not find Firebase key on classpath: {}. Trying file system.", serviceAccountPath);
+                    try {
+                        serviceAccount = new FileInputStream(serviceAccountPath);
+                    } catch (IOException ex) {
+                        log.error("Failed to load Firebase key from file system.", ex);
+                    }
+                }
+
+                if (serviceAccount != null) {
+                    options = FirebaseOptions.builder()
+                            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                            .build();
+                }
+            }
+
+            if (options == null) {
                 log.warn("Firebase service account path is empty. Using application default credentials. If this fails, FCM won't work.");
                 try {
                     options = FirebaseOptions.builder()


### PR DESCRIPTION
Configured the `processResources` task in `build.gradle` to securely process the `fcm-key.json` from the `record-private/private` submodule directory. The `FirebaseConfig` was modified to load this file correctly from the JAR classpath, and missing properties default to empty to prevent test failures.

---
*PR created automatically by Jules for task [10343335911666993789](https://jules.google.com/task/10343335911666993789) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Firebase credential initialization with a two-stage loading mechanism that attempts classpath resource access before falling back to filesystem access
  * Made Firebase key path configuration optional by changing the property to have a default empty value
  * Updated Gradle build configuration to add resource processing step for FCM key file handling during build

<!-- end of auto-generated comment: release notes by coderabbit.ai -->