### PR TITLE
Fix waiver claim restrictions and frontend button disabled state

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/dto/WaiverBoardDto.java
+++ b/src/main/java/com/sayai/record/fantasy/dto/WaiverBoardDto.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 public class WaiverBoardDto {
     private Long transactionSeq;
+    private Long requesterId;
     private String requesterTeamName;
     private String playerName;
     private String playerTeam;

--- a/src/main/java/com/sayai/record/fantasy/service/FantasyRosterService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyRosterService.java
@@ -71,6 +71,7 @@ public class FantasyRosterService {
 
             return WaiverBoardDto.builder()
                     .transactionSeq(tx.getSeq())
+                    .requesterId(tx.getRequesterId())
                     .requesterTeamName(requesterTeam)
                     .playerName(player.getName())
                     .playerTeam(player.getTeam())
@@ -107,6 +108,8 @@ public class FantasyRosterService {
                 existingClaim.setClaimPlayerId(claimerId);
                 existingClaim.setClaimOrder(order.getOrderNum());
                 waiverClaimRepository.save(existingClaim);
+            } else {
+                throw new IllegalStateException("나보다 앞선 우선순위의 클레임이 존재합니다.");
             }
         } else {
             waiverClaimRepository.save(FantasyWaiverClaim.builder()

--- a/src/main/resources/templates/fantasy/trade.html
+++ b/src/main/resources/templates/fantasy/trade.html
@@ -306,7 +306,13 @@
                 waivers.forEach(w => {
                     const dateStr = new Date(w.waiverDate).toLocaleString();
                     const isClaimedByMe = (String(w.claimPlayerId) === String(currentUserId));
-                    const claimBtn = `<button class="btn-action btn-fa" onclick="claimWaiver(${w.transactionSeq})">Claim</button>`;
+                    const isWaivedByMe = (String(w.requesterId) === String(currentUserId));
+
+                    let claimBtn = `<button class="btn-action btn-fa" onclick="claimWaiver(${w.transactionSeq})">Claim</button>`;
+                    if (isWaivedByMe || isClaimedByMe) {
+                        claimBtn = `<button class="btn-action btn-disabled" disabled>Claim</button>`;
+                    }
+
                     const claimedStatus = w.claimPlayerId
                         ? `<br><small style="color:${isClaimedByMe ? '#007bff' : '#28a745'};">(현재 클레임 존재${isClaimedByMe ? ' - My Claim' : ''})</small>`
                         : '';


### PR DESCRIPTION
The issue required preventing users from claiming their own waived players from the waiver board, and disabling the claim button if the claim was successful or if the user was the original requester. It also required an error alert if a prior request (higher priority) existed.

- Updated `WaiverBoardDto` to include the `requesterId` field.
- In `FantasyRosterService.java`, populated `requesterId` when building `WaiverBoardDto`.
- In `FantasyRosterService.java`'s `claimWaiver` method, correctly throw an `IllegalStateException` with the exact message `"나보다 앞선 우선순위의 클레임이 존재합니다."` if the incoming claim has a lower priority (higher `orderNum`) than an existing claim on the transaction.
- In `trade.html`, added logic to disable the claim button if `isWaivedByMe` (using `w.requesterId`) or `isClaimedByMe` evaluates to true.

---
*PR created automatically by Jules for task [6064752115269304431](https://jules.google.com/task/6064752115269304431) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waiver board now clearly indicates which claims belong to you.
  * Claim button is automatically disabled for waivers you have already claimed.

* **Bug Fixes**
  * Waiver priority ordering is now strictly enforced when processing new claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->