### PR TITLE
Enforce Salary Cap during Roster Save

### DIFF
--- a/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
+++ b/src/main/java/com/sayai/record/fantasy/service/FantasyDraftService.java
@@ -436,6 +436,19 @@ public class FantasyDraftService {
         Map<Long, DraftPick> pickMap = myPicks.stream()
                 .collect(Collectors.toMap(DraftPick::getFantasyPlayerSeq, Function.identity()));
 
+        if (game.getSalaryCap() != null && game.getSalaryCap() > 0) {
+            Set<Long> pickedSeqs = myPicks.stream()
+                    .map(DraftPick::getFantasyPlayerSeq)
+                    .collect(Collectors.toSet());
+            List<FantasyPlayer> currentTeam = fantasyPlayerRepository.findAllById(pickedSeqs);
+            FantasyParticipant participant = fantasyParticipantRepository.findByFantasyGameSeqAndPlayerId(gameSeq, playerId).orElse(null);
+
+            int currentCost = com.sayai.record.fantasy.util.SalaryCapCalculator.calculateTeamCost(game, participant, currentTeam).getTotalCost();
+            if (currentCost > game.getSalaryCap()) {
+                throw new IllegalStateException("샐러리캡을 초과하여 저장할 수 없습니다. (현재: " + currentCost + " / 제한: " + game.getSalaryCap() + ")");
+            }
+        }
+
         // Check validation first
         if (updateDto.getEntries() != null) {
             Map<String, Integer> positionCounts = new java.util.HashMap<>();


### PR DESCRIPTION
Added salary cap validation in the `/apis/v1/fantasy/games/{gameSeq}/my-team/save` endpoint. This correctly validates a user's roster updates against the game's salary cap using the centralized `SalaryCapCalculator`.

---
*PR created automatically by Jules for task [13861062783101055796](https://jules.google.com/task/13861062783101055796) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added salary cap validation when updating fantasy rosters to prevent roster costs from exceeding the configured limit. If a roster update would violate the salary cap, the system now rejects the change with a clear error message indicating the current cost and cap limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->