### PR TITLE
Support background push popups on iOS PWA and Android Web

### DIFF
--- a/src/main/java/com/sayai/record/firebase/FcmService.java
+++ b/src/main/java/com/sayai/record/firebase/FcmService.java
@@ -1,9 +1,14 @@
 package com.sayai.record.firebase;
 
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushFcmOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +32,20 @@ public class FcmService {
                     .setNotification(Notification.builder()
                             .setTitle(title)
                             .setBody(body)
+                            .build())
+                    .setWebpushConfig(WebpushConfig.builder()
+                            .setFcmOptions(WebpushFcmOptions.builder()
+                                    .setLink("/")
+                                    .build())
+                            .build())
+                    .setAndroidConfig(AndroidConfig.builder()
+                            .setPriority(AndroidConfig.Priority.HIGH)
+                            .build())
+                    .setApnsConfig(ApnsConfig.builder()
+                            .setAps(Aps.builder()
+                                    .setSound("default")
+                                    .setContentAvailable(true)
+                                    .build())
                             .build())
                     .build();
 

--- a/src/main/java/com/sayai/record/firebase/FcmService.java
+++ b/src/main/java/com/sayai/record/firebase/FcmService.java
@@ -35,7 +35,7 @@ public class FcmService {
                             .build())
                     .setWebpushConfig(WebpushConfig.builder()
                             .setFcmOptions(WebpushFcmOptions.builder()
-                                    .setLink("/")
+                                    .setLink("/fantasy/trade")
                                     .build())
                             .build())
                     .setAndroidConfig(AndroidConfig.builder()


### PR DESCRIPTION
Configured FCM `Message` objects to properly display background popups. Added high priority to Android config, default sound to APNs config, and a root link to Webpush options to ensure native-like handling.

---
*PR created automatically by Jules for task [1462407517181337195](https://jules.google.com/task/1462407517181337195) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push notifications now include platform-specific settings: web notifications include a deep link to the trade screen, Android notifications are sent with high priority, and Apple/iOS notifications include default sound and a background content-available flag for improved handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->