### PR TITLE
Fix: Convert waiver application time to local timezone in trade.html

### DIFF
--- a/src/main/resources/templates/fantasy/trade.html
+++ b/src/main/resources/templates/fantasy/trade.html
@@ -304,7 +304,11 @@
                 }
 
                 waivers.forEach(w => {
-                    const dateStr = new Date(w.waiverDate).toLocaleString();
+                    let wDate = w.waiverDate;
+                    if (wDate && !wDate.endsWith('Z')) {
+                        wDate += 'Z';
+                    }
+                    const dateStr = new Date(wDate).toLocaleString();
                     const isClaimedByMe = (String(w.claimPlayerId) === String(currentUserId));
                     const isWaivedByMe = (String(w.requesterId) === String(currentUserId));
 


### PR DESCRIPTION
웨이버 신청 시각이 항상 UTC 시간으로 표시되던 버그를 수정했습니다. Javascript에서 `new Date()` 파싱 시 문자열이 `Z`로 끝나는지 확인하고, 그렇지 않으면 `Z`를 추가하여 명시적으로 UTC 시간임을 알려 브라우저의 로컬 시간대로 올바르게 변환되도록 처리했습니다.

---
*PR created automatically by Jules for task [3603533152690417298](https://jules.google.com/task/3603533152690417298) started by @YeonDo*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed waiver board date formatting to correctly interpret and display timestamps, particularly those without explicit UTC indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->